### PR TITLE
Use a Framebuffer for Drawing to LED Matrix

### DIFF
--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -341,7 +341,7 @@ Milliseconds time;
 uint16_t generated_rhythms[NUM_CHANNELS];
 Channel active_channel; // Channel that is currently active
 static Timeout internal_clock_timeout = { .duration = INTERNAL_CLOCK_PERIOD };
-static Timeout output_pulse_timeout = { .duration = 50 }; // Pulse length, set based on the time since last trigger
+static Timeout output_pulse_timeout = { .duration = 5 }; // Pulse length, set based on the time since last trigger
 
 static TimeoutOnce trig_indicator_timeout = { .inner = {.duration = INPUT_INDICATOR_FLASH_TIME} }; // Set based on the time since last trigger
 static TimeoutOnce reset_indicator_timeout = { .inner = {.duration = INPUT_INDICATOR_FLASH_TIME} }; // Set based on the time since last trigger

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -428,7 +428,7 @@ static inline int eeprom_addr_density(Channel channel);
 static inline int eeprom_addr_offset(Channel channel);
 static void active_channel_set(Channel channel);
 static uint8_t output_channel_led_x(OutputChannel channel);
-static void framebuffer_draw_to_led();
+static void framebuffer_draw_to_display();
 #define led_pixel_on(x, y) (led_pixel_set(x, y, true))
 #define led_pixel_off(x, y) (led_pixel_set(x, y, false))
 /// Set a single pixel on the LED Matrix to be on or off, using a coordinate 
@@ -958,6 +958,10 @@ void loop() {
     draw_channels();
   }
 
+  /* DRAW FRAMEBUFFER TO DISPLAY IF NEEDED */
+
+  framebuffer_draw_to_display();
+
   /* UPDATE LED SLEEP */
 
   if (input_events_contains_any_external(&events_in)) {
@@ -1207,7 +1211,7 @@ static uint8_t output_channel_led_x(OutputChannel channel) {
   return result;
 }
 
-static void framebuffer_draw_to_led() {
+static void framebuffer_draw_to_display() {
   for (uint8_t row = 0; row < LED_ROWS; row++) {
     bool needs_redraw = (framebuffer_row_needs_redraw >> row) & 0x01; 
     if (!needs_redraw) { continue; }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1134,6 +1134,11 @@ static inline void draw_channel(Channel channel) {
   uint8_t position = channel_state.position;
   uint16_t pattern = generated_rhythms[channel];
 
+  // Clear rows
+  uint8_t row = channel * 2;
+  framebuffer_row_off(row);
+  framebuffer_row_off(row + 1);
+
   if (adjustment_display_state.visible && (channel == adjustment_display_state.channel)) { 
     if (adjustment_display_state.parameter == EUCLIDEAN_PARAM_LENGTH) {
       draw_channel_length(channel, length);  
@@ -1147,8 +1152,6 @@ static inline void draw_channel(Channel channel) {
 
 static inline void draw_channel_length(Channel channel, uint8_t length) {
     uint8_t row = channel * 2;
-    framebuffer_row_off(row);
-    framebuffer_row_off(row + 1);
 
     for (uint8_t step = 0; step < length; step++) {
       uint8_t x = step;
@@ -1164,7 +1167,6 @@ static inline void draw_channel_length(Channel channel, uint8_t length) {
 
 static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern, uint8_t length, uint8_t position) {
   uint8_t y = channel * 2;
-  framebuffer_row_off(y);
 
   if (position < 8) {
     for (uint8_t step = 0; step < 8; step++) {
@@ -1184,15 +1186,12 @@ static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern,
 }
 
 static inline void draw_channel_playhead(uint8_t y, uint8_t position) {
-  framebuffer_row_off(y);
   uint8_t x = (position < 8) ? position : position - 8;
   framebuffer_pixel_blink_fast(x, y);
 }
 
 static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t length) {
     uint8_t row = channel * 2;
-    framebuffer_row_off(row);
-    framebuffer_row_off(row + 1);
 
     for (uint8_t step = 0; step < length; step++) {
       uint8_t x = step;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -262,7 +262,7 @@ Encoder Enc3(PIN_ENC_3B, PIN_ENC_3A); // Offset  / O
 // 1 is maximum number of devices that can be controlled
 LedControl lc = LedControl(PIN_OUT_LED_DATA, PIN_OUT_LED_CLOCK, PIN_OUT_LED_SELECT, 1);
 
-/// Color representing the illumination state of a pixel on the LED matrix 
+/// Represents a method of deciding on illumination of a pixel on the LED matrix
 /// display.
 typedef enum Color {
   /// Do not light up this pixel

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -475,7 +475,10 @@ static inline void framebuffer_pixel_set_fast(uint8_t x, uint8_t y, Color color)
 /// Colors are 2-bit.
 /// @param y Zero-indexed position, from top to bottom.
 static inline void framebuffer_row_set(uint8_t y, uint16_t pixels);
-static void framebuffer_draw_to_display();
+/// Copy one row of the framebuffer to the LED matrix. We only copy one row of 
+/// the framebuffer to the LED matrix per cycle to avoid having to wait on the 
+/// display driver chip.
+static void framebuffer_copy_row_to_display();
 void led_sleep();
 void led_wake();
 void led_anim_wake();
@@ -1007,9 +1010,9 @@ void loop() {
     draw_channels();
   }
 
-  /* DRAW FRAMEBUFFER TO DISPLAY IF NEEDED */
+  /* UPDATE LED DISPLAY */
 
-  framebuffer_draw_to_display();
+  framebuffer_copy_row_to_display();
 
   /* UPDATE LED SLEEP */
 
@@ -1325,10 +1328,8 @@ static inline void framebuffer_row_set(uint8_t y, uint16_t pixels) {
   #endif
 }
 
-static void framebuffer_draw_to_display() {
+static void framebuffer_copy_row_to_display() {
   #if FRAMEBUFFER_ENABLED
-  // We only copy one row of the framebuffer to the LED matrix per cycle to 
-  // avoid having to wait on the display driver chip
   uint8_t row = (framebuffer_out_row) % LED_ROWS;
   uint16_t fb_row_bits = framebuffer[row];
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1301,6 +1301,9 @@ static void framebuffer_draw_to_display() {
 
     lc.setRow(LED_ADDR, row, to_draw);
   }
+
+  // Mark every row as having been drawn
+  framebuffer_row_needs_redraw = 0;
   #endif
 }
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1160,15 +1160,15 @@ static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t leng
 }
 
 static void draw_active_channel_display() {
-    uint8_t row_bits = B00000000;
+    uint16_t row_bits = 0;
     if (active_channel == CHANNEL_1) {
-      row_bits = B00000011;
+      row_bits = 0x5000; // Two left dots
     } else if (active_channel == CHANNEL_2) {
-      row_bits = B00011000;
+      row_bits = 0x0140; // Two middle dots
     } else if (active_channel == CHANNEL_3) {
-      row_bits = B11000000;
+      row_bits = 0x0005; // Two right dots
     } 
-    lc.setRow(LED_ADDR, LED_CH_SEL_Y, row_bits);
+    framebuffer_row_set(LED_CH_SEL_Y, row_bits);
 }
 
 static bool pattern_read(uint16_t pattern, uint8_t length, uint8_t position) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -431,6 +431,10 @@ static inline int eeprom_addr_density(Channel channel);
 static inline int eeprom_addr_offset(Channel channel);
 static void active_channel_set(Channel channel);
 static uint8_t output_channel_led_x(OutputChannel channel);
+#define framebuffer_pixel_on(x, y) (framebuffer_pixel_set(x, y, PALETTE_ON))
+#define framebuffer_pixel_off(x, y) (framebuffer_pixel_set(x, y, PALETTE_OFF))
+#define framebuffer_pixel_blink(x, y) (framebuffer_pixel_set(x, y, PALETTE_BLINK))
+static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color);
 static void framebuffer_draw_to_display();
 #define led_pixel_on(x, y) (led_pixel_set(x, y, true))
 #define led_pixel_off(x, y) (led_pixel_set(x, y, false))
@@ -1212,6 +1216,18 @@ static uint8_t output_channel_led_x(OutputChannel channel) {
     result = LED_OUT_OFFBEAT_X;
   }
   return result;
+}
+
+static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color) {
+  // Clear existing color
+  uint16_t mask = 0x0003; // Must be 16 bits because it gets inverted
+  framebuffer[y] &= ~(mask << (x * 2));
+
+  // Set new color
+  framebuffer[y] |= (color << (x * 2));
+
+  // Mark as needing redraw
+  framebuffer_row_needs_redraw |= (0x01 << y);
 }
 
 static void framebuffer_draw_to_display() {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1146,7 +1146,7 @@ static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern,
 static inline void draw_channel_playhead(uint8_t y, uint8_t position) {
   framebuffer_row_off(y);
   uint8_t x = (position < 8) ? position : position - 8;
-  framebuffer_pixel_on(x, y);
+  framebuffer_pixel_blink(x, y);
 }
 
 static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t length) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -575,7 +575,7 @@ void loop() {
   InputEvents events_in = INPUT_EVENTS_EMPTY;
 
   // READ TRIG AND RESET INPUTS
-  int trig_in_value = digitalRead(PIN_IN_TRIG); // Pulse input
+  int trig_in_value = digitalRead(PIN_IN_TRIG);
   int reset_button = analogRead(A1);
 
   // RESET INPUT & BUTTON

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1330,14 +1330,14 @@ static void framebuffer_copy_row_to_display() {
 
   uint8_t to_draw = 0;
   for (uint8_t col = 0; col < LED_COLUMNS; col++) {
-    uint8_t palette_idx = (fb_row_bits >> (col * 2)) & 0b00000011;
+    Color color = (Color)((fb_row_bits >> (col * 2)) & 0b00000011);
 
-    if (palette_idx == COLOR_ANTS) {
+    if (color == COLOR_ANTS) {
       to_draw |= (anim_marching_ants(anim_ants_frame, col, row) << col);
-    } else if (palette_idx == COLOR_DAZZLE) {
+    } else if (color == COLOR_DAZZLE) {
       to_draw |= (anim_dazzle(anim_dazzle_frame, col, row) << col);
     } else {
-      to_draw |= (palette_idx << col);
+      to_draw |= (color << col);
     }
   }
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -276,6 +276,8 @@ typedef enum Color {
 /// which corresponds to one of the `PALLETTE_` constants.
 bool palette[4] = { false, true, false, false };
 
+Timeout palette_blink_timeout = { .duration = PALETTE_BLINK_INTERVAL };
+
 /// Buffer that can be drawn into and manipulated before being drawn to the
 /// hardware display. 2 bits per pixel, so it supports 4 colors. Each color is
 /// an index into `palette`.
@@ -876,6 +878,11 @@ void loop() {
   // FINISH ANY PULSES THAT ARE ACTIVE
   if (output_any_active() && (timeout_fired(&output_pulse_timeout, time))) {
     output_clear_all();
+  }
+
+  /* DRAWING - UPDATE BLINK COLOR */
+  if(timeout_fired_loop(&palette_blink_timeout, time)) {
+    palette[COLOR_BLINK] = ~palette[COLOR_BLINK];
   }
 
   /* DRAWING - OUTPUT INDICATORS */

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -269,7 +269,7 @@ LedControl lc = LedControl(PIN_OUT_LED_DATA, PIN_OUT_LED_CLOCK, PIN_OUT_LED_SELE
 
 /// Each pixel in the framebuffer indexes into this palette with a 2-bit number, 
 /// which corresponds to one of the `PALLETTE_` constants.
-bool palette[4];
+bool palette[4] = { false, true, false, false };
 
 /// Buffer that can be drawn into and manipulated before being drawn to the
 /// hardware display. 2 bits per pixel, so it supports 4 colors. Each color is

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -405,9 +405,6 @@ Microseconds cycle_time_max;
 static Timeout log_cycle_time_timeout = { .duration = LOGGING_CYCLE_TIME_INTERVAL };
 #endif
 
-#define REDRAW_MASK_NONE  0b00000000
-#define REDRAW_MASK_ALL   0b00000111
-
 /* INTERNAL */
 
 /// Returns true if `events` contains any externally-generated events

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1212,7 +1212,6 @@ static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t leng
 }
 
 static void draw_active_channel_display() {
-    #if FRAMEBUFFER_ENABLED
     uint16_t row_bits = 0;
     if (active_channel == CHANNEL_1) {
       row_bits = 0x0005; // Two left dots
@@ -1222,17 +1221,6 @@ static void draw_active_channel_display() {
       row_bits = 0x5000; // Two right dots
     } 
     framebuffer_row_set(LED_CH_SEL_Y, row_bits);
-    #else
-    uint8_t row_bits = 0;
-    if (active_channel == CHANNEL_1) {
-      row_bits = B00000011; // Two left dots
-    } else if (active_channel == CHANNEL_2) {
-      row_bits = B00011000; // Two middle dots
-    } else if (active_channel == CHANNEL_3) {
-      row_bits = B11000000; // Two right dots
-    } 
-    framebuffer_row_set(LED_CH_SEL_Y, row_bits);
-    #endif
 }
 
 static inline uint8_t anim_dazzle(uint8_t frame, uint8_t x, uint8_t y) {
@@ -1294,37 +1282,24 @@ static uint8_t output_channel_led_x(OutputChannel channel) {
 }
 
 static inline void framebuffer_pixel_set(uint8_t x, uint8_t y, Color color) {
-  #if FRAMEBUFFER_ENABLED
   // Clear existing color
   uint16_t mask = 0x0003; // Must be 16 bits because it gets inverted
   framebuffer[y] &= ~(mask << (x * 2));
 
   // Set new color
   framebuffer[y] |= (color << (x * 2));
-  #else
-  lc.setLed(LED_ADDR, y, 7 - x, (bool)color);
-  #endif
 }
 
 static inline void framebuffer_pixel_set_fast(uint8_t x, uint8_t y, Color color) {
-  #if FRAMEBUFFER_ENABLED
   // Set new color
   framebuffer[y] |= (color << (x * 2));
-  #else
-  lc.setLed(LED_ADDR, y, 7 - x, (bool)color);
-  #endif
 }
 
 static inline void framebuffer_row_set(uint8_t y, uint16_t pixels) {
-  #if FRAMEBUFFER_ENABLED
   framebuffer[y] = pixels;
-  #else
-  lc.setRow(LED_ADDR, y, pixels);
-  #endif
 }
 
 static void framebuffer_copy_row_to_display() {
-  #if FRAMEBUFFER_ENABLED
   uint8_t row = (framebuffer_out_row) % LED_ROWS;
   uint16_t fb_row_bits = framebuffer[row];
 
@@ -1345,8 +1320,6 @@ static void framebuffer_copy_row_to_display() {
 
   // Next cycle, copy the next row of the framebuffer to the LED matrix
   framebuffer_out_row = (framebuffer_out_row + 1) % LED_ROWS;
-
-  #endif
 }
 
 /// Load state from EEPROM into the given `EuclideanState`

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -26,7 +26,8 @@ extern "C" {
     - Patterns generated are now accurate to the original Euclidean Rhythms paper.
     - LED sleep timeout now takes into account encoder manipulations
   - UI Polish:
-    - Reset is now visible immediately in the sequencers.
+    - The generated pattern for a channel is now visible while adjusting its length.
+    - The effects of resetting the sequencers is now immediately visible.
     - There is now an indicator LED for Reset input, next to the one labeled "Trig".
     - Output indicator LEDs now stay lit for the entire duration of the step.
     - The "Trig" LED indicator now illuminates every clock pulse instead of alternating ones.
@@ -420,7 +421,7 @@ static void sequencer_advance();
 static uint8_t sequencer_read_current_step();
 static void draw_channels();
 static inline void draw_channel(Channel channel);
-static inline void draw_channel_length(Channel channel, uint8_t length);
+static inline void draw_channel_length(Channel channel, uint16_t pattern, uint8_t length);
 static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern, uint8_t length, uint8_t position);
 static inline void draw_channel_playhead(uint8_t y, uint8_t position);
 static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t length);
@@ -1135,7 +1136,7 @@ static inline void draw_channel(Channel channel) {
 
   if (adjustment_display_state.visible && (channel == adjustment_display_state.channel)) { 
     if (adjustment_display_state.parameter == EUCLIDEAN_PARAM_LENGTH) {
-      draw_channel_length(channel, length);  
+      draw_channel_length(channel, pattern, length);  
     } else {
       draw_channel_pattern(channel, pattern, length);
     }
@@ -1144,19 +1145,21 @@ static inline void draw_channel(Channel channel) {
   }
 }
 
-static inline void draw_channel_length(Channel channel, uint8_t length) {
-    uint8_t row = channel * 2;
+static inline void draw_channel_length(Channel channel, uint16_t pattern, uint8_t length) {
+  draw_channel_pattern(channel, pattern, length);
 
-    for (uint8_t step = 0; step < length; step++) {
-      uint8_t x = step;
-      uint8_t y = row;
-      if (step > 7) {
-        x -= 8;
-        y += 1;
-      }
+  uint8_t row = channel * 2;
 
-      framebuffer_pixel_blink_fast(x, y);
+  for (uint8_t step = length; step < 16; step++) {
+    uint8_t x = step;
+    uint8_t y = row;
+    if (step > 7) {
+      x -= 8;
+      y += 1;
     }
+
+    framebuffer_pixel_blink_fast(x, y);
+  }
 }
 
 static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern, uint8_t length, uint8_t position) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -283,12 +283,6 @@ Timeout palette_blink_timeout = { .duration = PALETTE_BLINK_INTERVAL };
 /// an index into `palette`.
 uint16_t framebuffer[LED_ROWS];
 
-/// Each boolean is true if that row of the framebuffer (from top to bottom) has
-/// been modified since it has been drawn to the LED matrix. We skip rows that
-/// don't need to be redrawn to reduce visual latency further if only some rows 
-/// are being redrawn.
-bool framebuffer_row_needs_redraw[LED_ROWS];
-
 /// To keep latency from spiking, we only draw one row of the framebuffer to the
 /// LED matrix at a time. The row that gets drawn rotates between the 8 rows of 
 /// the framebuffer to keep visual latency equal for all rows. 
@@ -1288,8 +1282,6 @@ static inline void framebuffer_pixel_set(uint8_t x, uint8_t y, Color color) {
 
   // Set new color
   framebuffer[y] |= (color << (x * 2));
-
-  framebuffer_row_needs_redraw[y] = true;
   #else
   lc.setLed(LED_ADDR, y, 7 - x, (bool)color);
   #endif
@@ -1307,8 +1299,6 @@ static inline void framebuffer_pixel_set_fast(uint8_t x, uint8_t y, Color color)
 static inline void framebuffer_row_set(uint8_t y, uint16_t pixels) {
   #if FRAMEBUFFER_ENABLED
   framebuffer[y] = pixels;
-
-  framebuffer_row_needs_redraw[y] = true;
   #else
   lc.setRow(LED_ADDR, y, pixels);
   #endif

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1287,6 +1287,15 @@ static inline void framebuffer_pixel_set(uint8_t x, uint8_t y, Color color) {
   #endif
 }
 
+static inline void framebuffer_pixel_set_fast(uint8_t x, uint8_t y, Color color) {
+  #if FRAMEBUFFER_ENABLED
+  // Set new color
+  framebuffer[y] |= (color << (x * 2));
+  #else
+  lc.setLed(LED_ADDR, y, 7 - x, (bool)color);
+  #endif
+}
+
 static inline void framebuffer_row_set(uint8_t y, uint16_t pixels) {
   #if FRAMEBUFFER_ENABLED
   framebuffer[y] = pixels;
@@ -1295,15 +1304,6 @@ static inline void framebuffer_row_set(uint8_t y, uint16_t pixels) {
   framebuffer_row_needs_redraw |= (0x01 << y);
   #else
   lc.setRow(LED_ADDR, y, pixels);
-  #endif
-}
-
-static inline void framebuffer_pixel_set_fast(uint8_t x, uint8_t y, Color color) {
-  #if FRAMEBUFFER_ENABLED
-  // Set new color
-  framebuffer[y] |= (color << (x * 2));
-  #else
-  lc.setLed(LED_ADDR, y, 7 - x, (bool)color);
   #endif
 }
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -431,7 +431,6 @@ static void draw_channels();
 static inline void draw_channel(Channel channel);
 static inline void draw_channel_length(Channel channel, uint16_t pattern, uint8_t length);
 static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern, uint8_t length, uint8_t position);
-static inline void draw_channel_playhead(uint8_t y, uint8_t position);
 static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t length);
 static void draw_active_channel_display();
 static inline uint8_t anim_dazzle(uint8_t frame, uint8_t x, uint8_t y);
@@ -1195,11 +1194,6 @@ static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern,
     }
     framebuffer_pixel_set_fast(x, y, color);
   }
-}
-
-static inline void draw_channel_playhead(uint8_t y, uint8_t position) {
-  uint8_t x = (position < 8) ? position : position - 8;
-  framebuffer_pixel_on_fast(x, y);
 }
 
 static void draw_channel_pattern(Channel channel, uint16_t pattern, uint8_t length) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -268,6 +268,8 @@ typedef enum PaletteColor {
   PALETTE_ON = 1,
   /// Blink this LED
   PALETTE_BLINK = 2,
+  // NOTE: Palette index 3 is not used yet - it could be used for special 
+  // effects or a second blink speed.
 } PaletteColor;
 
 /// Each pixel in the framebuffer indexes into this palette with a 2-bit number, 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -1118,7 +1118,7 @@ static inline void draw_channel_length(Channel channel, uint8_t length) {
         y += 1;
       }
 
-      framebuffer_pixel_on(x, y);
+      framebuffer_pixel_blink(x, y);
     }
 }
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -261,16 +261,16 @@ Encoder Enc3(PIN_ENC_3B, PIN_ENC_3A); // Offset  / O
 LedControl lc = LedControl(PIN_OUT_LED_DATA, PIN_OUT_LED_CLOCK, PIN_OUT_LED_SELECT, 1);
 
 /// Index into color palette representing the illumination state of an LED
-typedef enum PaletteColor {
+typedef enum Color {
   /// Do not light up this LED
-  PALETTE_OFF = 0,
+  COLOR_OFF = 0,
   /// Light up this LED
-  PALETTE_ON = 1,
+  COLOR_ON = 1,
   /// Blink this LED
-  PALETTE_BLINK = 2,
-  // NOTE: Palette index 3 is not used yet - it could be used for special 
+  COLOR_BLINK = 2,
+  // NOTE: Color index 3 is not used yet - it could be used for special 
   // effects or a second blink speed.
-} PaletteColor;
+} Color;
 
 /// Each pixel in the framebuffer indexes into this palette with a 2-bit number, 
 /// which corresponds to one of the `PALLETTE_` constants.
@@ -433,16 +433,16 @@ static inline int eeprom_addr_density(Channel channel);
 static inline int eeprom_addr_offset(Channel channel);
 static void active_channel_set(Channel channel);
 static uint8_t output_channel_led_x(OutputChannel channel);
-#define framebuffer_pixel_on(x, y) (framebuffer_pixel_set(x, y, PALETTE_ON))
-#define framebuffer_pixel_off(x, y) (framebuffer_pixel_set(x, y, PALETTE_OFF))
-#define framebuffer_pixel_blink(x, y) (framebuffer_pixel_set(x, y, PALETTE_BLINK))
+#define framebuffer_pixel_on(x, y) (framebuffer_pixel_set(x, y, COLOR_ON))
+#define framebuffer_pixel_off(x, y) (framebuffer_pixel_set(x, y, COLOR_OFF))
+#define framebuffer_pixel_blink(x, y) (framebuffer_pixel_set(x, y, COLOR_BLINK))
 /// Set a single pixel on the framebuffer to the 2-bit color, using a coordinate 
 /// system that is not mirrored left-to-right.
 /// @param x Zero-indexed position, from left to right.
 /// @param y Zero-indexed position, from top to bottom.
-/// @param color 2-bit color. `PALETTE_OFF` or `0` turns off pixel, `PALETTE_ON` 
+/// @param color 2-bit color. `COLOR_OFF` or `0` turns off pixel, `COLOR_ON` 
 /// or `1` turns it on.
-static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color);
+static void framebuffer_pixel_set(uint8_t x, uint8_t y, Color color);
 /// Clear a row of pixels on the framebuffer
 /// @param y Zero-indexed position, from top to bottom.
 #define framebuffer_row_off(y) (framebuffer_row_set(y, 0))
@@ -908,7 +908,7 @@ void loop() {
       
       uint8_t active_step = (output_channels_active_step_bitflags >> out_channel) & 0x01;
 
-      framebuffer_pixel_set(x, LED_OUT_Y, (PaletteColor)active_step);
+      framebuffer_pixel_set(x, LED_OUT_Y, (Color)active_step);
     }
   }
 
@@ -1222,7 +1222,7 @@ static uint8_t output_channel_led_x(OutputChannel channel) {
   return result;
 }
 
-static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color) {
+static void framebuffer_pixel_set(uint8_t x, uint8_t y, Color color) {
   // Clear existing color
   uint16_t mask = 0x0003; // Must be 16 bits because it gets inverted
   framebuffer[y] &= ~(mask << (x * 2));

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -26,6 +26,7 @@ extern "C" {
     - Patterns generated are now accurate to the original Euclidean Rhythms paper.
     - LED sleep timeout now takes into account encoder manipulations
   - UI Polish:
+    - All steps of the generated pattern are now visible at all times.
     - The generated pattern for a channel is now visible while adjusting its length.
     - The effects of resetting the sequencers is now immediately visible.
     - There is now an indicator LED for Reset input, next to the one labeled "Trig".
@@ -1174,23 +1175,26 @@ static inline void draw_channel_length(Channel channel, uint16_t pattern, uint8_
 }
 
 static inline void draw_channel_with_playhead(Channel channel, uint16_t pattern, uint8_t length, uint8_t position) {
-  uint8_t y = channel * 2;
+  uint8_t row = channel * 2;
 
-  if (position < 8) {
-    for (uint8_t step = 0; step < 8; step++) {
-      if (pattern_read(pattern, length, step) && (step < length)) {
-        framebuffer_pixel_on_fast(step, y);
-      }
+  for (uint8_t step = 0; step < length; step++) {
+    uint8_t x = step;
+    uint8_t y = row;
+    if (step > 7) {
+      x -= 8;
+      y += 1;
     }
-  } else {
-    for (uint8_t step = 8; step < 16; step++) {
-      if (pattern_read(pattern, length, step) && (step < length)) {
-        framebuffer_pixel_on_fast(step - 8, y);
-      }
+
+    bool active_step = pattern_read(pattern, length, step);
+    bool playhead_here = (step == position);
+    Color color = COLOR_OFF;
+    if (playhead_here) {
+      color = COLOR_DAZZLE;
+    } else if (active_step) {
+      color = COLOR_ON;
     }
+    framebuffer_pixel_set_fast(x, y, color);
   }
-
-  draw_channel_playhead(y + 1, position);
 }
 
 static inline void draw_channel_playhead(uint8_t y, uint8_t position) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -228,6 +228,13 @@ extern "C" {
 #define BEAT_POSITION_MAX 15
 #define BEAT_POSITION_DEFAULT 0
 
+/// Index into color palette representing not lighting up an LED
+#define PALETTE_OFF 0;
+/// Index into color palette representing lighting up an LED
+#define PALETTE_ON 1;
+/// Index into color palette representing a blinking LED
+#define PALETTE_BLINK 2;
+
 /// Row of LED Display marked "CH SEL" on panel
 #define LED_CH_SEL_Y 6
 /// Column of LED Display marked "TRIG" on panel
@@ -259,6 +266,15 @@ Encoder Enc3(PIN_ENC_3B, PIN_ENC_3A); // Offset  / O
 // (from LedControl.h library)
 // 1 is maximum number of devices that can be controlled
 LedControl lc = LedControl(PIN_OUT_LED_DATA, PIN_OUT_LED_CLOCK, PIN_OUT_LED_SELECT, 1);
+
+/// Each pixel in the framebuffer indexes into this palette with a 2-bit number, 
+/// which corresponds to one of the `PALLETTE_` constants.
+bool palette[4];
+
+/// Buffer that can be drawn into and manipulated before being drawn to the
+/// hardware display. 2 bits per pixel, so it supports 4 colors. Each color is
+/// an index into `palette`.
+uint16_t framebuffer[LED_ROWS];
 
 /// References one of the three channels
 typedef enum Channel {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -228,13 +228,6 @@ extern "C" {
 #define BEAT_POSITION_MAX 15
 #define BEAT_POSITION_DEFAULT 0
 
-/// Index into color palette representing not lighting up an LED
-#define PALETTE_OFF 0;
-/// Index into color palette representing lighting up an LED
-#define PALETTE_ON 1;
-/// Index into color palette representing a blinking LED
-#define PALETTE_BLINK 2;
-
 /// Row of LED Display marked "CH SEL" on panel
 #define LED_CH_SEL_Y 6
 /// Column of LED Display marked "TRIG" on panel
@@ -266,6 +259,16 @@ Encoder Enc3(PIN_ENC_3B, PIN_ENC_3A); // Offset  / O
 // (from LedControl.h library)
 // 1 is maximum number of devices that can be controlled
 LedControl lc = LedControl(PIN_OUT_LED_DATA, PIN_OUT_LED_CLOCK, PIN_OUT_LED_SELECT, 1);
+
+/// Index into color palette representing the illumination state of an LED
+typedef enum PaletteColor {
+  /// Do not light up this LED
+  PALETTE_OFF = 0,
+  /// Light up this LED
+  PALETTE_ON = 1,
+  /// Blink this LED
+  PALETTE_BLINK = 2,
+} PaletteColor;
 
 /// Each pixel in the framebuffer indexes into this palette with a 2-bit number, 
 /// which corresponds to one of the `PALLETTE_` constants.

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -262,8 +262,8 @@ Encoder Enc3(PIN_ENC_3B, PIN_ENC_3A); // Offset  / O
 // 1 is maximum number of devices that can be controlled
 LedControl lc = LedControl(PIN_OUT_LED_DATA, PIN_OUT_LED_CLOCK, PIN_OUT_LED_SELECT, 1);
 
-/// Index into color palette representing the illumination state of a pixel on
-/// the LED matrix display.
+/// Color representing the illumination state of a pixel on the LED matrix 
+/// display.
 typedef enum Color {
   /// Do not light up this pixel
   COLOR_OFF = 0,
@@ -275,10 +275,6 @@ typedef enum Color {
   COLOR_ANTS = 3
 } Color;
 
-/// Each pixel in the framebuffer indexes into this palette with a 2-bit number, 
-/// which corresponds to one of the `PALLETTE_` constants.
-bool palette[4] = { false, true, false, false };
-
 #define ANIM_DAZZLE_NUM_FRAMES 2
 Timeout anim_dazzle_timeout = { .duration = ANIM_DAZZLE_INTERVAL };
 uint8_t anim_dazzle_frame = 0;
@@ -288,8 +284,7 @@ Timeout anim_ants_timeout = { .duration = ANIM_ANTS_INTERVAL };
 uint8_t anim_ants_frame = 0;
 
 /// Buffer that can be drawn into and manipulated before being drawn to the
-/// hardware display. 2 bits per pixel, so it supports 4 colors. Each color is
-/// an index into `palette`.
+/// hardware display. 2 bits per pixel, so it supports 4 colors.
 uint16_t framebuffer[LED_ROWS];
 
 /// To keep latency from spiking, we only draw one row of the framebuffer to the
@@ -910,7 +905,7 @@ void loop() {
     output_clear_all();
   }
 
-  /* DRAWING - UPDATE PALETTE COLORS */
+  /* DRAWING - UPDATE ANIMATIONS */
   if(timeout_fired_loop(&anim_dazzle_timeout, time)) {
     anim_dazzle_frame = (anim_dazzle_frame + 1) % ANIM_DAZZLE_NUM_FRAMES;
   }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -435,6 +435,7 @@ static uint8_t output_channel_led_x(OutputChannel channel);
 #define framebuffer_pixel_off(x, y) (framebuffer_pixel_set(x, y, PALETTE_OFF))
 #define framebuffer_pixel_blink(x, y) (framebuffer_pixel_set(x, y, PALETTE_BLINK))
 static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color);
+static void framebuffer_row_off(uint8_t y);
 static void framebuffer_draw_to_display();
 #define led_pixel_on(x, y) (led_pixel_set(x, y, true))
 #define led_pixel_off(x, y) (led_pixel_set(x, y, false))
@@ -1225,6 +1226,14 @@ static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color) {
 
   // Set new color
   framebuffer[y] |= (color << (x * 2));
+
+  // Mark as needing redraw
+  framebuffer_row_needs_redraw |= (0x01 << y);
+}
+
+static void framebuffer_row_off(uint8_t y) {
+  // Clear existing colors
+  framebuffer[y] = 0;
 
   // Mark as needing redraw
   framebuffer_row_needs_redraw |= (0x01 << y);

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -276,6 +276,10 @@ bool palette[4];
 /// an index into `palette`.
 uint16_t framebuffer[LED_ROWS];
 
+/// Bitflags, where each bit is true if that row of the LED (from top to bottom) 
+/// needs to be redrawn this frame.
+uint8_t framebuffer_row_needs_redraw;
+
 /// References one of the three channels
 typedef enum Channel {
   CHANNEL_1,

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -907,7 +907,7 @@ void loop() {
 
   /* DRAWING - UPDATE BLINK COLOR */
   if(timeout_fired_loop(&palette_blink_timeout, time)) {
-    palette[COLOR_BLINK] = ~palette[COLOR_BLINK];
+    palette[COLOR_BLINK] = !palette[COLOR_BLINK];
   }
 
   /* DRAWING - OUTPUT INDICATORS */

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -435,7 +435,8 @@ static uint8_t output_channel_led_x(OutputChannel channel);
 #define framebuffer_pixel_off(x, y) (framebuffer_pixel_set(x, y, PALETTE_OFF))
 #define framebuffer_pixel_blink(x, y) (framebuffer_pixel_set(x, y, PALETTE_BLINK))
 static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color);
-static void framebuffer_row_off(uint8_t y);
+#define framebuffer_row_off(y) (framebuffer_row_set(y, 0))
+static void framebuffer_row_set(uint8_t y, uint16_t pixels);
 static void framebuffer_draw_to_display();
 #define led_pixel_on(x, y) (led_pixel_set(x, y, true))
 #define led_pixel_off(x, y) (led_pixel_set(x, y, false))
@@ -1231,9 +1232,8 @@ static void framebuffer_pixel_set(uint8_t x, uint8_t y, PaletteColor color) {
   framebuffer_row_needs_redraw |= (0x01 << y);
 }
 
-static void framebuffer_row_off(uint8_t y) {
-  // Clear existing colors
-  framebuffer[y] = 0;
+static void framebuffer_row_set(uint8_t y, uint16_t pixels) {
+  framebuffer[y] = pixels;
 
   // Mark as needing redraw
   framebuffer_row_needs_redraw |= (0x01 << y);

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -814,13 +814,13 @@ void loop() {
     #if LOGGING_ENABLED
     if (param_changed == EUCLIDEAN_PARAM_LENGTH) {
       Serial.print("length: ");
-      Serial.print(length);
+      Serial.println(length);
     } else if (param_changed == EUCLIDEAN_PARAM_DENSITY) {
-      Serial.print(" density: ");
-      Serial.print(density);
+      Serial.print("density: ");
+      Serial.println(density);
     } else {
-      Serial.print(" offset: ");
-      Serial.print(offset);
+      Serial.print("offset: ");
+      Serial.println(offset);
     }
     #endif
   }

--- a/src/config.h
+++ b/src/config.h
@@ -6,7 +6,7 @@
 #define LED_SLEEP_TIME 300000 // Milliseconds until LED matrix sleeps (5 minutes)
 #define INPUT_INDICATOR_FLASH_TIME 16 // Milliseconds input indicators flash when being illuminated
 #define OUTPUT_INDICATOR_BLINK_TIME 16 // Milliseconds output indicators blink for when being illuminated
-#define PALETTE_BLINK_INTERVAL 32 // Default period of the `COLOR_BLINK` palette color, in milliseconds
+#define PALETTE_BLINK_INTERVAL 150 // Default period of the `COLOR_BLINK` palette color, in milliseconds
 #define READ_DELAY 50 // For debouncing
 #define INTERNAL_CLOCK_PERIOD 125 // Milliseconds between internal clock ticks
 

--- a/src/config.h
+++ b/src/config.h
@@ -14,10 +14,14 @@
 #define INTERNAL_CLOCK_DEFAULT 0 // 0 = Internal clock begins disabled, 1 = begins enabled
 #define EEPROM_READ 1 // 0 = Reading from EEPROM disabled, 1 = enabled
 #define EEPROM_WRITE 1 // 0 = Writing to EEPROM disabled, 1 = enabled
+#define FRAMEBUFFER_ENABLED 1 // 0 = Framebuffer disabled, 1 = write directly to LED
+
+/* DEBUG FEATURES */
+
 #define LOGGING_ENABLED 0 // 0 = Logging over serial disabled, 1 = enabled
 #define LOGGING_INPUT 0 // 0 = Don't log Input events, 1 = Log input events
 #define LOGGING_CH1_POSITION 0 // 0 = Don't log Channel 1 position updates, 1 = Log position updates
-#define LOGGING_CYCLE_TIME 0 // 0 = Don't log max cycle time in the last interval, 1 = Do log max cycle time
-#define LOGGING_CYCLE_TIME_INTERVAL 1000 // Milliseconds to capture the max cycle time during
+#define LOGGING_CYCLE_TIME 1 // 0 = Don't log max cycle time in the last interval, 1 = Do log max cycle time
+#define LOGGING_CYCLE_TIME_INTERVAL 2000 // Milliseconds to capture the max cycle time during
 
 #endif /* CONFIG_H_ */ 

--- a/src/config.h
+++ b/src/config.h
@@ -13,7 +13,7 @@
 
 #define INTERNAL_CLOCK_DEFAULT 0 // 0 = Internal clock begins disabled, 1 = begins enabled
 #define EEPROM_READ 1 // 0 = Reading from EEPROM disabled, 1 = enabled
-#define EEPROM_WRITE 1 // 0 = Writing to EEPROM disabled, 1 = enabled
+#define EEPROM_WRITE 0 // 0 = Writing to EEPROM disabled, 1 = enabled
 #define FRAMEBUFFER_ENABLED 1 // 0 = Framebuffer disabled, 1 = write directly to LED
 
 /* DEBUG FEATURES */
@@ -22,6 +22,6 @@
 #define LOGGING_INPUT 0 // 0 = Don't log Input events, 1 = Log input events
 #define LOGGING_CH1_POSITION 0 // 0 = Don't log Channel 1 position updates, 1 = Log position updates
 #define LOGGING_CYCLE_TIME 1 // 0 = Don't log max cycle time in the last interval, 1 = Do log max cycle time
-#define LOGGING_CYCLE_TIME_INTERVAL 2000 // Milliseconds to capture the max cycle time during
+#define LOGGING_CYCLE_TIME_INTERVAL 1000 // Milliseconds to capture the max cycle time during
 
 #endif /* CONFIG_H_ */ 

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,7 @@
 #define LED_SLEEP_TIME 300000 // Milliseconds until LED matrix sleeps (5 minutes)
 #define INPUT_INDICATOR_FLASH_TIME 16 // Milliseconds input indicators flash when being illuminated
 #define OUTPUT_INDICATOR_BLINK_TIME 16 // Milliseconds output indicators blink for when being illuminated
+#define PALETTE_BLINK_INTERVAL 32 // Default period of the `COLOR_BLINK` palette color, in milliseconds
 #define READ_DELAY 50 // For debouncing
 #define INTERNAL_CLOCK_PERIOD 125 // Milliseconds between internal clock ticks
 

--- a/src/config.h
+++ b/src/config.h
@@ -7,6 +7,7 @@
 #define INPUT_INDICATOR_FLASH_TIME 16 // Milliseconds input indicators flash when being illuminated
 #define OUTPUT_INDICATOR_BLINK_TIME 16 // Milliseconds output indicators blink for when being illuminated
 #define PALETTE_BLINK_INTERVAL 150 // Default period of the `COLOR_BLINK` palette color, in milliseconds
+#define PALETTE_DAZZLE_INTERVAL 32 // Default period of the `COLOR_DAZZLE` palette color, in milliseconds
 #define READ_DELAY 50 // For debouncing
 #define INTERNAL_CLOCK_PERIOD 125 // Milliseconds between internal clock ticks
 

--- a/src/config.h
+++ b/src/config.h
@@ -16,7 +16,6 @@
 #define INTERNAL_CLOCK_DEFAULT 0 // 0 = Internal clock begins disabled, 1 = begins enabled
 #define EEPROM_READ 1 // 0 = Reading from EEPROM disabled, 1 = enabled
 #define EEPROM_WRITE 1 // 0 = Writing to EEPROM disabled, 1 = enabled
-#define FRAMEBUFFER_ENABLED 1 // 0 = Framebuffer disabled, 1 = write directly to LED
 
 /* DEBUG FEATURES */
 

--- a/src/config.h
+++ b/src/config.h
@@ -14,7 +14,7 @@
 
 #define INTERNAL_CLOCK_DEFAULT 0 // 0 = Internal clock begins disabled, 1 = begins enabled
 #define EEPROM_READ 1 // 0 = Reading from EEPROM disabled, 1 = enabled
-#define EEPROM_WRITE 0 // 0 = Writing to EEPROM disabled, 1 = enabled
+#define EEPROM_WRITE 1 // 0 = Writing to EEPROM disabled, 1 = enabled
 #define FRAMEBUFFER_ENABLED 1 // 0 = Framebuffer disabled, 1 = write directly to LED
 
 /* DEBUG FEATURES */

--- a/src/config.h
+++ b/src/config.h
@@ -17,5 +17,7 @@
 #define LOGGING_ENABLED 0 // 0 = Logging over serial disabled, 1 = enabled
 #define LOGGING_INPUT 0 // 0 = Don't log Input events, 1 = Log input events
 #define LOGGING_CH1_POSITION 0 // 0 = Don't log Channel 1 position updates, 1 = Log position updates
+#define LOGGING_CYCLE_TIME 0 // 0 = Don't log max cycle time in the last interval, 1 = Do log max cycle time
+#define LOGGING_CYCLE_TIME_INTERVAL 1000 // Milliseconds to capture the max cycle time during
 
 #endif /* CONFIG_H_ */ 

--- a/src/config.h
+++ b/src/config.h
@@ -6,8 +6,8 @@
 #define LED_SLEEP_TIME 300000 // Milliseconds until LED matrix sleeps (5 minutes)
 #define INPUT_INDICATOR_FLASH_TIME 16 // Milliseconds input indicators flash when being illuminated
 #define OUTPUT_INDICATOR_BLINK_TIME 16 // Milliseconds output indicators blink for when being illuminated
-#define PALETTE_BLINK_INTERVAL 150 // Default period of the `COLOR_BLINK` palette color, in milliseconds
-#define PALETTE_DAZZLE_INTERVAL 32 // Default period of the `COLOR_DAZZLE` palette color, in milliseconds
+#define ANIM_DAZZLE_INTERVAL 32 // Default animation frame interval for the `COLOR_DAZZLE` palette color, in milliseconds
+#define ANIM_ANTS_INTERVAL 24 // Default animation frame interval for the `COLOR_ANTS` palette color, in milliseconds
 #define READ_DELAY 50 // For debouncing
 #define INTERNAL_CLOCK_PERIOD 125 // Milliseconds between internal clock ticks
 

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -29,6 +29,8 @@
 
 // Number of rows in LED Matrix
 #define LED_ROWS 8
+// Number of columns in LED Matrix
+#define LED_COLUMNS 8
 
 #define RESET_PIN_THRESHOLD 100
 

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -27,6 +27,9 @@
 // LED Matrix address
 #define LED_ADDR 0
 
+// Number of rows in LED Matrix
+#define LED_ROWS 8
+
 #define RESET_PIN_THRESHOLD 100
 
 #endif /* HARDWARE_H_ */ 

--- a/src/types.h
+++ b/src/types.h
@@ -2,5 +2,6 @@
 #define TYPES_H_
 
 typedef unsigned long Milliseconds;
+typedef unsigned long Microseconds;
 
 #endif /* TYPES_H_ */ 


### PR DESCRIPTION
Instead of drawing directly to the LED matrix display, UI code now draws to a 2-bit (4 color) framebuffer that is then copied to the LED display one row at a time. This has a number of benefits, including:

- Drawing indirectly allows for optimizations around when to set pixels on the LED matrix. Copying 1 row per main loop cycle from the framebuffer to the LED alleviates a bottleneck there. This has brought output latency down significantly (See performance measurements at the end of this description).
- The use of 2 additional colors in the palette beyond simply "off" and "on" enables straightforward implementation of pixel-level visual effects including global blinking and marching ants.
- Indirect drawing also allows for future visual effects such as scrolling, which is planned to be used for an upcoming menu system.

## Performance Measurements

The Euclidean was set up with all three channels having 16 length, Ch 1 & 2 having 9 density, and Ch 3 having 16 density. No parameters were adjusted during tests. All measurements captured with an oscilloscope.  Measurements in the table are worst-observed Trig In -> Channel 3 Output latency, when the module is clocked by various sources to test real-world and extreme settings. 

| Clock Source | Original Firmware  | Now |
| ------------- | ------------- | ------------- |
| **Single Pulse** | 9.1ms | 0.4ms |
| **Korg SQ-1 Sequencer at Fastest Tempo** | 9.1ms | 0.6ms |
| **Audio-Rate Clock (Maximum Supported)** |  80hz (12ms period) | 330hz (3ms period) |

At this point, the maximum audio-rate frequency supported is limited by the length of the output pulses produced.