### PR TITLE
Add programmatic parameters

### DIFF
--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -57,26 +57,27 @@ static const EuclideanChannelUpdate EUCLIDEAN_UPDATE_EMPTY = {
     .offset_changed = false,
 };
 
-#define PARAM_RUNTIME_FLAG_MODIFIED 0x1
-#define PARAM_RUNTIME_FLAG_NEEDS_WRITE 0x2
+#define PARAM_FLAG_MODIFIED 0x1
+#define PARAM_FLAG_NEEDS_WRITE 0x2
 
-/// Properties of parameters that need to be modified at runtime
-typedef struct ParamRuntime {
-	/// The value of the parameter. It is assumed to always be in bounds.
-	uint8_t value;
-	/// Bitflags storing properties about the param, indexed via `PARAM_RUNTIME_FLAG_*` defines.
-	uint8_t flags;
-} ParamRuntime;
-
-static const ParamRuntime PARAM_RUNTIME_DEFAULT = {
-    .value = 0,
-    .flags = 0,
-};
-
-/// Maximum size of `params_runtime` list. Must be large enough to the `ParamId` type for any mode.
+/// Maximum size of `ParamsRuntime`'s tables. Must be large enough to store the
+/// `ParamId` type for any mode.
 #define PARAMS_RUNTIME_MAX 10
-static uint8_t params_runtime_len;
-static ParamRuntime params_runtime[PARAMS_RUNTIME_MAX];
+
+/// Parameter properties which need to be modified at runtime. Each table has
+/// the same length (`.len`), and they are indexed by a mode's associated
+/// `ParamId` type.
+typedef struct ParamsRuntime {
+	/// Number of elements in tables
+	uint8_t len;
+	/// List of parameter values of length `.len`. The values are always assumed to be in bounds.
+	uint8_t values[PARAMS_RUNTIME_MAX];
+	/// List of parameter properties, stored as bitflags, of length `.len`. Bitflags are indexed
+	/// via `PARAM_FLAG_*` defines.
+	uint8_t flags[PARAMS_RUNTIME_MAX];
+} ParamsRuntime;
+
+static ParamsRuntime params_runtime;
 
 #if LOGGING_ENABLED && LOGGING_CYCLE_TIME
 Microseconds cycle_time_max;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -94,6 +94,7 @@ static Timeout log_cycle_time_timeout = {.duration = LOGGING_CYCLE_TIME_INTERVAL
 static void init_serial(void);
 static ChannelOpt channel_for_encoder(EncoderIdx enc_idx);
 static Milliseconds calc_playhead_flash_time(Milliseconds clock_period);
+static inline void param_set(ParamIdx idx, uint8_t value);
 /// Read the bits specified in `mask`
 static inline uint8_t param_flags_get(ParamIdx idx, uint8_t mask);
 /// Set the bits specified in `mask` to 1, leaving the others untouched
@@ -214,7 +215,7 @@ void loop() {
 			euclidean_state.channels[channel].density = density;
 
 #if PARAM_TABLES
-			param_flags_set_modified_and_needs_write(density_idx);
+			param_set(density_idx, density);
 #else
 			params_update.density = density;
 			params_update.density_changed = true;
@@ -225,7 +226,7 @@ void loop() {
 			euclidean_state.channels[channel].offset = offset;
 
 #if PARAM_TABLES
-			param_flags_set_modified_and_needs_write(offset_idx);
+			param_set(offset_idx, offset);
 #else
 			params_update.offset = offset;
 			params_update.offset_changed = true;
@@ -241,7 +242,7 @@ void loop() {
 		}
 
 #if PARAM_TABLES
-		param_flags_set_modified_and_needs_write(length_idx);
+		param_set(length_idx, length);
 #else
 		params_update.length = length;
 		params_update.length_changed = true;
@@ -270,7 +271,7 @@ void loop() {
 		euclidean_state.channels[channel].density = density;
 
 #if PARAM_TABLES
-		param_flags_set_modified_and_needs_write(density_idx);
+		param_set(density_idx, density);
 #else
 		params_update.density = density;
 		params_update.density_changed = true;
@@ -299,7 +300,7 @@ void loop() {
 		euclidean_state.channels[channel].offset = offset;
 
 #if PARAM_TABLES
-		param_flags_set_modified_and_needs_write(offset_idx);
+		param_set(offset_idx, offset);
 #else
 		params_update.offset = offset;
 		params_update.offset_changed = true;
@@ -538,6 +539,11 @@ static ChannelOpt channel_for_encoder(EncoderIdx enc_idx) {
 			return CHANNEL_OPT_NONE;
 			break;
 	}
+}
+
+static inline void param_set(ParamIdx idx, uint8_t value) {
+	params.values[idx] = value;
+	param_flags_set(idx, (PARAM_FLAG_MODIFIED | PARAM_FLAG_NEEDS_WRITE));
 }
 
 static Milliseconds calc_playhead_flash_time(Milliseconds clock_period) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -643,18 +643,18 @@ static void euclid_params_validate() {
 }
 
 static void eeprom_load_tables() {
-#if EEPROM_READ
 	Mode mode = active_mode;
 	uint8_t num_params = mode_num_params[mode];
 
+#if EEPROM_READ
 	for (uint8_t idx = 0; idx < num_params; idx++) {
 		Address addr = param_address(mode, (ParamIdx)idx);
 		params.values[idx] = EEPROM.read(addr);
 		params.flags[idx] = PARAM_FLAGS_NONE;
 	}
+#endif
 
 	params.len = num_params;
-#endif
 }
 
 static void eeprom_save_all_needing_write() {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -132,7 +132,7 @@ void loop() {
 		int length = euclid_get_length(&params, channel);
 		uint8_t density = euclid_get_density(&params, channel);
 		uint8_t offset = euclid_get_offset(&params, channel);
-		uint8_t position = euclid_state.channel_positions[channel];
+		uint8_t position = euclid_state.sequencer_positions[channel];
 
 		// Keep length in bounds
 		if (length >= BEAT_LENGTH_MAX) {
@@ -163,7 +163,7 @@ void loop() {
 
 		// Reset position if length has been reduced past it
 		if (position >= length) {
-			euclid_state.channel_positions[channel] = 0;
+			euclid_state.sequencer_positions[channel] = 0;
 		}
 	}
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -301,10 +301,16 @@ void loop() {
 	// Update Generated Rhythms Based On Parameter Changes
 	if (knob_moved_for_param.valid) {
 		Channel channel = active_channel;
+#if PARAM_TABLES
+		uint8_t length = euclid_param_get_length(channel);
+		uint8_t density = euclid_param_get_density(channel);
+		uint8_t offset = euclid_param_get_offset(channel);
+#else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		uint8_t length = channel_state.length;
 		uint8_t density = channel_state.density;
 		uint8_t offset = channel_state.offset;
+#endif
 
 		generated_rhythms[channel] = euclidean_pattern_rotate(length, density, offset);
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -342,7 +342,7 @@ void loop() {
 
 		generated_rhythms[channel] = euclidean_pattern_rotate(length, density, offset);
 
-#if LOGGING_ENABLED
+#if !PARAM_TABLES && LOGGING_ENABLED
 		if (knob_moved_for_param.inner == EUCLIDEAN_PARAM_LENGTH) {
 			Serial.print("length: ");
 			Serial.println(length);

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -70,7 +70,9 @@ static Timeout log_cycle_time_timeout = {.duration = LOGGING_CYCLE_TIME_INTERVAL
 static void init_serial(void);
 static ChannelOpt channel_for_encoder(EncoderIdx enc_idx);
 static Milliseconds calc_playhead_flash_time(Milliseconds clock_period);
-static inline void param_set(ParamIdx idx, uint8_t value);
+/// Set the param referenced by `idx` to `value`, and set its flags to indicate
+/// that it has been modified and needs to be written to the EEPROM.
+static inline void param_and_flags_set(ParamIdx idx, uint8_t value);
 /// Read the bits specified in `mask`
 static inline uint8_t param_flags_get(ParamIdx idx, uint8_t mask);
 /// Set the bits specified in `mask` to 1, leaving the others untouched
@@ -197,7 +199,7 @@ void loop() {
 			euclidean_state.channels[channel].density = density;
 
 #if PARAM_TABLES
-			param_set(density_idx, density);
+			param_and_flags_set(density_idx, density);
 #else
 			params_update.density = density;
 			params_update.density_changed = true;
@@ -208,7 +210,7 @@ void loop() {
 			euclidean_state.channels[channel].offset = offset;
 
 #if PARAM_TABLES
-			param_set(offset_idx, offset);
+			param_and_flags_set(offset_idx, offset);
 #else
 			params_update.offset = offset;
 			params_update.offset_changed = true;
@@ -224,7 +226,7 @@ void loop() {
 		}
 
 #if PARAM_TABLES
-		param_set(length_idx, length);
+		param_and_flags_set(length_idx, length);
 #else
 		params_update.length = length;
 		params_update.length_changed = true;
@@ -253,7 +255,7 @@ void loop() {
 		euclidean_state.channels[channel].density = density;
 
 #if PARAM_TABLES
-		param_set(density_idx, density);
+		param_and_flags_set(density_idx, density);
 #else
 		params_update.density = density;
 		params_update.density_changed = true;
@@ -282,7 +284,7 @@ void loop() {
 		euclidean_state.channels[channel].offset = offset;
 
 #if PARAM_TABLES
-		param_set(offset_idx, offset);
+		param_and_flags_set(offset_idx, offset);
 #else
 		params_update.offset = offset;
 		params_update.offset_changed = true;
@@ -523,7 +525,7 @@ static ChannelOpt channel_for_encoder(EncoderIdx enc_idx) {
 	}
 }
 
-static inline void param_set(ParamIdx idx, uint8_t value) {
+static inline void param_and_flags_set(ParamIdx idx, uint8_t value) {
 	params.values[idx] = value;
 	param_flags_set(idx, (PARAM_FLAG_MODIFIED | PARAM_FLAG_NEEDS_WRITE));
 }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -109,8 +109,10 @@ static void euclid_params_validate();
 /// Load state for the active mode into `active_mode_params`.
 static void eeprom_load_tables();
 static void eeprom_save_all_needing_write();
+#if !PARAM_TABLES
 /// Load state from EEPROM into the given `EuclideanState`
 static void eeprom_load(EuclideanState *s);
+#endif
 static inline Address eeprom_addr_length(Channel channel);
 static inline Address eeprom_addr_density(Channel channel);
 static inline Address eeprom_addr_offset(Channel channel);
@@ -128,9 +130,12 @@ void setup() {
 
 	led_init();
 	led_sleep_init(now);
+#if PARAM_TABLES
 	active_mode_switch(MODE_EUCLID);
+#else
 	eeprom_load(&euclidean_state);
 	euclid_validate_state(&euclidean_state);
+#endif
 	init_serial();
 	input_init();
 	output_init();
@@ -652,6 +657,7 @@ static void eeprom_save_all_needing_write() {
 #endif
 }
 
+#if !PARAM_TABLES
 static void eeprom_load(EuclideanState *s) {
 	/*
 	EEPROM Schema:
@@ -670,6 +676,7 @@ static void eeprom_load(EuclideanState *s) {
 	}
 #endif
 }
+#endif
 
 static inline Address eeprom_addr_length(Channel channel) { return (channel * 2) + 1; }
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -23,8 +23,6 @@
 
 #include <euclidean.h>
 
-typedef int Address;
-
 /* GLOBALS */
 
 static Milliseconds last_clock_or_reset;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -81,8 +81,8 @@ static inline void param_flags_set(ParamIdx idx, uint8_t mask);
 static inline void param_flags_clear(ParamIdx idx, uint8_t mask);
 static void param_flags_clear_all_modified();
 static void active_mode_switch(Mode mode);
-static void params_validate(ParamsRuntime *params, Mode mode);
-static void euclid_params_validate(ParamsRuntime *params);
+static void params_validate(Params *params, Mode mode);
+static void euclid_params_validate(Params *params);
 /// Load state for the given mode into `params`.
 static void eeprom_params_load(Mode mode);
 static void eeprom_save_all_needing_write();
@@ -610,7 +610,7 @@ static void active_mode_switch(Mode mode) {
 	params_validate(&params, mode);
 }
 
-static void params_validate(ParamsRuntime *params, Mode mode) {
+static void params_validate(Params *params, Mode mode) {
 	switch (mode) {
 		case MODE_EUCLID:
 			euclid_params_validate(params);
@@ -618,7 +618,7 @@ static void params_validate(ParamsRuntime *params, Mode mode) {
 	}
 }
 
-static void euclid_params_validate(ParamsRuntime *params) {
+static void euclid_params_validate(Params *params) {
 	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
 		Channel channel = (Channel)c;
 		uint8_t length = euclid_get_length(params, channel);

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -646,13 +646,15 @@ static void eeprom_load_tables() {
 	Mode mode = active_mode;
 	uint8_t num_params = mode_num_params[mode];
 
-#if EEPROM_READ
 	for (uint8_t idx = 0; idx < num_params; idx++) {
+#if EEPROM_READ
 		Address addr = param_address(mode, (ParamIdx)idx);
 		params.values[idx] = EEPROM.read(addr);
+#else
+		params.values[idx] = 0;
+#endif
 		params.flags[idx] = PARAM_FLAGS_NONE;
 	}
-#endif
 
 	params.len = num_params;
 }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -57,6 +57,27 @@ static const EuclideanChannelUpdate EUCLIDEAN_UPDATE_EMPTY = {
     .offset_changed = false,
 };
 
+#define PARAM_RUNTIME_FLAG_MODIFIED 0x1
+#define PARAM_RUNTIME_FLAG_NEEDS_WRITE 0x2
+
+/// Properties of parameters that need to be modified at runtime
+typedef struct ParamRuntime {
+	/// The value of the parameter. It is assumed to always be in bounds.
+	uint8_t value;
+	/// Bitflags storing properties about the param, indexed via `PARAM_RUNTIME_FLAG_*` defines.
+	uint8_t flags;
+} ParamRuntime;
+
+static const ParamRuntime PARAM_RUNTIME_DEFAULT = {
+    .value = 0,
+    .flags = 0,
+};
+
+/// Maximum size of `params_runtime` list. Must be large enough to the `ParamId` type for any mode.
+#define PARAMS_RUNTIME_MAX 10
+static uint8_t params_runtime_len;
+static ParamRuntime params_runtime[PARAMS_RUNTIME_MAX];
+
 #if LOGGING_ENABLED && LOGGING_CYCLE_TIME
 Microseconds cycle_time_max;
 static Timeout log_cycle_time_timeout = {.duration = LOGGING_CYCLE_TIME_INTERVAL};

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -84,7 +84,7 @@ static void active_mode_switch(Mode mode);
 static void params_validate(Params *params, Mode mode);
 static void euclid_params_validate(Params *params);
 /// Load state for the given mode into `params`.
-static void eeprom_params_load(Mode mode);
+static void eeprom_params_load(Params *params, Mode mode);
 static void eeprom_save_all_needing_write();
 #if !PARAM_TABLES
 /// Load state from EEPROM into the given `EuclideanState`
@@ -606,7 +606,7 @@ static void param_flags_clear_all_modified() {
 
 static void active_mode_switch(Mode mode) {
 	active_mode = mode;
-	eeprom_params_load(mode);
+	eeprom_params_load(&params, mode);
 	params_validate(&params, mode);
 }
 
@@ -637,20 +637,20 @@ static void euclid_params_validate(Params *params) {
 	}
 }
 
-static void eeprom_params_load(Mode mode) {
+static void eeprom_params_load(Params *params, Mode mode) {
 	uint8_t num_params = mode_num_params[mode];
 
 	for (uint8_t idx = 0; idx < num_params; idx++) {
 #if EEPROM_READ
 		Address addr = param_address(mode, (ParamIdx)idx);
-		params.values[idx] = EEPROM.read(addr);
+		params->values[idx] = EEPROM.read(addr);
 #else
 		params.values[idx] = 0;
 #endif
-		params.flags[idx] = PARAM_FLAGS_NONE;
+		params->flags[idx] = PARAM_FLAGS_NONE;
 	}
 
-	params.len = num_params;
+	params->len = num_params;
 }
 
 static void eeprom_save_all_needing_write() {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -122,9 +122,9 @@ void setup() {
 	for (int a = 0; a < NUM_CHANNELS; a++) {
 #if PARAM_TABLES
 		Channel channel = (Channel)a;
-		uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
-		uint8_t density = euclid_param_get(channel, EUCLIDEAN_PARAM_DENSITY);
-		uint8_t offset = euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
+		uint8_t length = euclid_param_get_length(channel);
+		uint8_t density = euclid_param_get_density(channel);
+		uint8_t offset = euclid_param_get_offset(channel);
 #else
 		uint8_t length = euclidean_state.channels[a].length;
 		uint8_t density = euclidean_state.channels[a].density;
@@ -592,9 +592,9 @@ static void active_mode_validate() {
 static void euclid_params_validate() {
 	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
 		Channel channel = (Channel)c;
-		uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
-		uint8_t density = euclid_param_get(channel, EUCLIDEAN_PARAM_DENSITY);
-		uint8_t offset = euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
+		uint8_t length = euclid_param_get_length(channel);
+		uint8_t density = euclid_param_get_density(channel);
+		uint8_t offset = euclid_param_get_offset(channel);
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
 			euclid_param_set(channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -76,6 +76,7 @@ typedef struct ParamsRuntime {
 	uint8_t flags[PARAMS_RUNTIME_MAX];
 } ParamsRuntime;
 
+/// Stores the runtime information of the active mode's parameters.
 static ParamsRuntime params;
 
 #if LOGGING_ENABLED && LOGGING_CYCLE_TIME

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -81,10 +81,10 @@ static inline void param_flags_set(ParamIdx idx, uint8_t mask);
 static inline void param_flags_clear(ParamIdx idx, uint8_t mask);
 static void param_flags_clear_all_modified();
 static void active_mode_switch(Mode mode);
-static void active_mode_validate(Mode mode);
+static void params_validate(Mode mode);
 static void euclid_params_validate();
 /// Load state for the given mode into `params`.
-static void eeprom_load_tables(Mode mode);
+static void eeprom_params_load(Mode mode);
 static void eeprom_save_all_needing_write();
 #if !PARAM_TABLES
 /// Load state from EEPROM into the given `EuclideanState`
@@ -606,11 +606,11 @@ static void param_flags_clear_all_modified() {
 
 static void active_mode_switch(Mode mode) {
 	active_mode = mode;
-	eeprom_load_tables(mode);
-	active_mode_validate(mode);
+	eeprom_params_load(mode);
+	params_validate(mode);
 }
 
-static void active_mode_validate(Mode mode) {
+static void params_validate(Mode mode) {
 	switch (mode) {
 		case MODE_EUCLID:
 			euclid_params_validate();
@@ -637,7 +637,7 @@ static void euclid_params_validate() {
 	}
 }
 
-static void eeprom_load_tables(Mode mode) {
+static void eeprom_params_load(Mode mode) {
 	uint8_t num_params = mode_num_params[mode];
 
 	for (uint8_t idx = 0; idx < num_params; idx++) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -81,10 +81,10 @@ static inline void param_flags_set(ParamIdx idx, uint8_t mask);
 static inline void param_flags_clear(ParamIdx idx, uint8_t mask);
 static void param_flags_clear_all_modified();
 static void active_mode_switch(Mode mode);
-static void active_mode_validate();
+static void active_mode_validate(Mode mode);
 static void euclid_params_validate();
-/// Load state for the active mode into `active_mode_params`.
-static void eeprom_load_tables();
+/// Load state for the given mode into `params`.
+static void eeprom_load_tables(Mode mode);
 static void eeprom_save_all_needing_write();
 #if !PARAM_TABLES
 /// Load state from EEPROM into the given `EuclideanState`
@@ -606,12 +606,12 @@ static void param_flags_clear_all_modified() {
 
 static void active_mode_switch(Mode mode) {
 	active_mode = mode;
-	eeprom_load_tables();
-	active_mode_validate();
+	eeprom_load_tables(mode);
+	active_mode_validate(mode);
 }
 
-static void active_mode_validate() {
-	switch (active_mode) {
+static void active_mode_validate(Mode mode) {
+	switch (mode) {
 		case MODE_EUCLID:
 			euclid_params_validate();
 			break;
@@ -637,8 +637,7 @@ static void euclid_params_validate() {
 	}
 }
 
-static void eeprom_load_tables() {
-	Mode mode = active_mode;
+static void eeprom_load_tables(Mode mode) {
 	uint8_t num_params = mode_num_params[mode];
 
 	for (uint8_t idx = 0; idx < num_params; idx++) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -62,7 +62,6 @@ static inline void param_flags_clear(Params *params, ParamIdx idx, uint8_t mask)
 static void param_flags_clear_all_modified(Params *params, Mode mode);
 static void active_mode_switch(Mode mode);
 static void params_validate(Params *params, Mode mode);
-static void euclid_params_validate(Params *params);
 /// Load state for the given mode into `params`.
 static void eeprom_params_load(Params *params, Mode mode);
 static void eeprom_save_all_needing_write(Params *params, Mode mode);
@@ -460,25 +459,6 @@ static void params_validate(Params *params, Mode mode) {
 		case MODE_EUCLID:
 			euclid_params_validate(params);
 			break;
-	}
-}
-
-static void euclid_params_validate(Params *params) {
-	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
-		Channel channel = (Channel)c;
-		uint8_t length = euclid_get_length(params, channel);
-		uint8_t density = euclid_get_density(params, channel);
-		uint8_t offset = euclid_get_offset(params, channel);
-
-		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
-			euclid_param_set(params, channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
-		}
-		if (density > BEAT_DENSITY_MAX || density > length) {
-			euclid_param_set(params, channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
-		}
-		if (offset > BEAT_OFFSET_MAX || offset > length) {
-			euclid_param_set(params, channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
-		}
 	}
 }
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -173,9 +173,11 @@ void loop() {
 	EuclideanChannelUpdate params_update = EUCLIDEAN_UPDATE_EMPTY;
 #endif
 
+#if PARAM_TABLES
 	ParamIdx length_idx = euclid_param_idx(active_channel, EUCLIDEAN_PARAM_LENGTH);
 	ParamIdx density_idx = euclid_param_idx(active_channel, EUCLIDEAN_PARAM_DENSITY);
 	ParamIdx offset_idx = euclid_param_idx(active_channel, EUCLIDEAN_PARAM_OFFSET);
+#endif
 
 	// Handle Length Knob Movement
 	int nknob = events_in.enc_move[ENCODER_1];
@@ -183,17 +185,18 @@ void loop() {
 		knob_moved_for_param = euclidean_param_opt(EUCLIDEAN_PARAM_LENGTH);
 
 		Channel channel = active_channel;
-		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 #if PARAM_TABLES
 		int length = euclid_param_get_length(channel);
 		uint8_t density = euclid_param_get_density(channel);
 		uint8_t offset = euclid_param_get_offset(channel);
+		uint8_t position = euclidean_state.channel_positions[channel];
 #else
+		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		int length = channel_state.length;
 		uint8_t density = channel_state.density;
 		uint8_t offset = channel_state.offset;
-#endif
 		uint8_t position = channel_state.position;
+#endif
 
 		// Keep length in bounds
 		if (length >= BEAT_LENGTH_MAX) {
@@ -209,40 +212,47 @@ void loop() {
 		// Reduce density and offset to remain in line with the new length if necessary
 		if ((density >= (length + nknob)) && (density > 1)) {
 			density += nknob;
-			euclidean_state.channels[channel].density = density;
 
 #if PARAM_TABLES
 			param_and_flags_set(density_idx, density);
 #else
+			euclidean_state.channels[channel].density = density;
+
 			params_update.density = density;
 			params_update.density_changed = true;
 #endif
 		}
 		if ((offset >= (length + nknob)) && (offset < 16)) {
 			offset += nknob;
-			euclidean_state.channels[channel].offset = offset;
 
 #if PARAM_TABLES
 			param_and_flags_set(offset_idx, offset);
 #else
+			euclidean_state.channels[channel].offset = offset;
+
 			params_update.offset = offset;
 			params_update.offset_changed = true;
 #endif
 		}
 
 		length += nknob;
-		euclidean_state.channels[channel].length = length;
 
 #if PARAM_TABLES
 		param_and_flags_set(length_idx, length);
 #else
+		euclidean_state.channels[channel].length = length;
+
 		params_update.length = length;
 		params_update.length_changed = true;
 #endif
 
 		// Reset position if length has been reduced past it
 		if (position >= length) {
+#if PARAM_TABLES
+			euclidean_state.channel_positions[channel] = 0;
+#else
 			euclidean_state.channels[channel].position = 0;
+#endif
 		}
 	}
 
@@ -270,11 +280,12 @@ void loop() {
 		}
 
 		density += kknob;
-		euclidean_state.channels[channel].density = density;
 
 #if PARAM_TABLES
 		param_and_flags_set(density_idx, density);
 #else
+		euclidean_state.channels[channel].density = density;
+
 		params_update.density = density;
 		params_update.density_changed = true;
 #endif
@@ -304,11 +315,12 @@ void loop() {
 		}
 
 		offset += oknob;
-		euclidean_state.channels[channel].offset = offset;
 
 #if PARAM_TABLES
 		param_and_flags_set(offset_idx, offset);
 #else
+		euclidean_state.channels[channel].offset = offset;
+
 		params_update.offset = offset;
 		params_update.offset_changed = true;
 #endif

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -184,9 +184,15 @@ void loop() {
 
 		Channel channel = active_channel;
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
+#if PARAM_TABLES
+		int length = euclid_param_get_length(channel);
+		uint8_t density = euclid_param_get_density(channel);
+		uint8_t offset = euclid_param_get_offset(channel);
+#else
 		int length = channel_state.length;
 		uint8_t density = channel_state.density;
 		uint8_t offset = channel_state.offset;
+#endif
 		uint8_t position = channel_state.position;
 
 		// Keep length in bounds
@@ -227,17 +233,17 @@ void loop() {
 		length += nknob;
 		euclidean_state.channels[channel].length = length;
 
-		// Reset position if length has been reduced past it
-		if (position >= length) {
-			euclidean_state.channels[channel].position = 0;
-		}
-
 #if PARAM_TABLES
 		param_and_flags_set(length_idx, length);
 #else
 		params_update.length = length;
 		params_update.length_changed = true;
 #endif
+
+		// Reset position if length has been reduced past it
+		if (position >= length) {
+			euclidean_state.channels[channel].position = 0;
+		}
 	}
 
 	// Handle Density Knob Movement
@@ -246,9 +252,14 @@ void loop() {
 		knob_moved_for_param = euclidean_param_opt(EUCLIDEAN_PARAM_DENSITY);
 
 		Channel channel = active_channel;
+#if PARAM_TABLES
+		int length = euclid_param_get_length(channel);
+		uint8_t density = euclid_param_get_density(channel);
+#else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		int length = channel_state.length;
 		int density = channel_state.density;
+#endif
 
 		// Keep density in bounds
 		if (density + kknob > length) {
@@ -275,9 +286,14 @@ void loop() {
 		knob_moved_for_param = euclidean_param_opt(EUCLIDEAN_PARAM_OFFSET);
 
 		Channel channel = active_channel;
+#if PARAM_TABLES
+		int length = euclid_param_get_length(channel);
+		uint8_t offset = euclid_param_get_offset(channel);
+#else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		int length = channel_state.length;
 		int offset = channel_state.offset;
+#endif
 
 		// Keep offset in bounds
 		if (offset + oknob > length - 1) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -121,9 +121,9 @@ void setup() {
 	for (int a = 0; a < NUM_CHANNELS; a++) {
 #if PARAM_TABLES
 		Channel channel = (Channel)a;
-		uint8_t length = euclid_param_get_length(channel);
-		uint8_t density = euclid_param_get_density(channel);
-		uint8_t offset = euclid_param_get_offset(channel);
+		uint8_t length = euclid_get_length(&params, channel);
+		uint8_t density = euclid_get_density(&params, channel);
+		uint8_t offset = euclid_get_offset(&params, channel);
 #else
 		uint8_t length = euclidean_state.channels[a].length;
 		uint8_t density = euclidean_state.channels[a].density;
@@ -185,9 +185,9 @@ void loop() {
 
 		Channel channel = active_channel;
 #if PARAM_TABLES
-		int length = euclid_param_get_length(channel);
-		uint8_t density = euclid_param_get_density(channel);
-		uint8_t offset = euclid_param_get_offset(channel);
+		int length = euclid_get_length(&params, channel);
+		uint8_t density = euclid_get_density(&params, channel);
+		uint8_t offset = euclid_get_offset(&params, channel);
 		uint8_t position = euclidean_state.channel_positions[channel];
 #else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
@@ -262,8 +262,8 @@ void loop() {
 
 		Channel channel = active_channel;
 #if PARAM_TABLES
-		int length = euclid_param_get_length(channel);
-		uint8_t density = euclid_param_get_density(channel);
+		int length = euclid_get_length(&params, channel);
+		uint8_t density = euclid_get_density(&params, channel);
 #else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		int length = channel_state.length;
@@ -297,8 +297,8 @@ void loop() {
 
 		Channel channel = active_channel;
 #if PARAM_TABLES
-		int length = euclid_param_get_length(channel);
-		uint8_t offset = euclid_param_get_offset(channel);
+		int length = euclid_get_length(&params, channel);
+		uint8_t offset = euclid_get_offset(&params, channel);
 #else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		int length = channel_state.length;
@@ -329,9 +329,9 @@ void loop() {
 	if (knob_moved_for_param.valid) {
 		Channel channel = active_channel;
 #if PARAM_TABLES
-		uint8_t length = euclid_param_get_length(channel);
-		uint8_t density = euclid_param_get_density(channel);
-		uint8_t offset = euclid_param_get_offset(channel);
+		uint8_t length = euclid_get_length(&params, channel);
+		uint8_t density = euclid_get_density(&params, channel);
+		uint8_t offset = euclid_get_offset(&params, channel);
 #else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		uint8_t length = channel_state.length;
@@ -621,18 +621,18 @@ static void params_validate(Mode mode) {
 static void euclid_params_validate() {
 	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
 		Channel channel = (Channel)c;
-		uint8_t length = euclid_param_get_length(channel);
-		uint8_t density = euclid_param_get_density(channel);
-		uint8_t offset = euclid_param_get_offset(channel);
+		uint8_t length = euclid_get_length(&params, channel);
+		uint8_t density = euclid_get_density(&params, channel);
+		uint8_t offset = euclid_get_offset(&params, channel);
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
-			euclid_param_set(channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
+			euclid_param_set(&params, channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
 		}
 		if (density > BEAT_DENSITY_MAX || density > length) {
-			euclid_param_set(channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
+			euclid_param_set(&params, channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
 		}
 		if (offset > BEAT_OFFSET_MAX || offset > length) {
-			euclid_param_set(channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
+			euclid_param_set(&params, channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
 		}
 	}
 }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -588,16 +588,13 @@ static void euclid_params_validate() {
 		uint8_t offset = euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
-			ParamIdx idx_length = euclid_param_idx(channel, EUCLIDEAN_PARAM_LENGTH);
-			params.values[idx_length] = BEAT_LENGTH_DEFAULT;
+			euclid_param_set(channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
 		}
 		if (density > BEAT_DENSITY_MAX || density > length) {
-			ParamIdx idx_density = euclid_param_idx(channel, EUCLIDEAN_PARAM_DENSITY);
-			params.values[idx_density] = BEAT_DENSITY_DEFAULT;
+			euclid_param_set(channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
 		}
 		if (offset > BEAT_OFFSET_MAX || offset > length) {
-			ParamIdx idx_offset = euclid_param_idx(channel, EUCLIDEAN_PARAM_OFFSET);
-			params.values[idx_offset] = BEAT_OFFSET_DEFAULT;
+			euclid_param_set(channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
 		}
 	}
 }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -116,23 +116,23 @@ void loop() {
 		active_channel = active_channel_new.inner;
 	}
 
-	EuclideanParamOpt knob_moved_for_param = EUCLIDEAN_PARAM_OPT_NONE;
+	EuclidParamOpt knob_moved_for_param = EUCLID_PARAM_OPT_NONE;
 	param_flags_clear_all_modified(&params, active_mode);
 
-	ParamIdx length_idx = euclid_param_idx(active_channel, EUCLIDEAN_PARAM_LENGTH);
-	ParamIdx density_idx = euclid_param_idx(active_channel, EUCLIDEAN_PARAM_DENSITY);
-	ParamIdx offset_idx = euclid_param_idx(active_channel, EUCLIDEAN_PARAM_OFFSET);
+	ParamIdx length_idx = euclid_param_idx(active_channel, EUCLID_PARAM_LENGTH);
+	ParamIdx density_idx = euclid_param_idx(active_channel, EUCLID_PARAM_DENSITY);
+	ParamIdx offset_idx = euclid_param_idx(active_channel, EUCLID_PARAM_OFFSET);
 
 	// Handle Length Knob Movement
 	int nknob = events_in.enc_move[ENCODER_1];
 	if (nknob != 0) {
-		knob_moved_for_param = euclidean_param_opt(EUCLIDEAN_PARAM_LENGTH);
+		knob_moved_for_param = euclid_param_opt(EUCLID_PARAM_LENGTH);
 
 		Channel channel = active_channel;
 		int length = euclid_get_length(&params, channel);
 		uint8_t density = euclid_get_density(&params, channel);
 		uint8_t offset = euclid_get_offset(&params, channel);
-		uint8_t position = euclidean_state.channel_positions[channel];
+		uint8_t position = euclid_state.channel_positions[channel];
 
 		// Keep length in bounds
 		if (length >= BEAT_LENGTH_MAX) {
@@ -163,14 +163,14 @@ void loop() {
 
 		// Reset position if length has been reduced past it
 		if (position >= length) {
-			euclidean_state.channel_positions[channel] = 0;
+			euclid_state.channel_positions[channel] = 0;
 		}
 	}
 
 	// Handle Density Knob Movement
 	int kknob = events_in.enc_move[ENCODER_2];
 	if (kknob != 0) {
-		knob_moved_for_param = euclidean_param_opt(EUCLIDEAN_PARAM_DENSITY);
+		knob_moved_for_param = euclid_param_opt(EUCLID_PARAM_DENSITY);
 
 		Channel channel = active_channel;
 		int length = euclid_get_length(&params, channel);
@@ -192,7 +192,7 @@ void loop() {
 	// Handle Offset Knob Movement
 	int oknob = events_in.enc_move[ENCODER_3];
 	if (oknob != 0) {
-		knob_moved_for_param = euclidean_param_opt(EUCLIDEAN_PARAM_OFFSET);
+		knob_moved_for_param = euclid_param_opt(EUCLID_PARAM_OFFSET);
 
 		Channel channel = active_channel;
 		int length = euclid_get_length(&params, channel);

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -50,16 +50,6 @@ static Timeout log_cycle_time_timeout = {.duration = LOGGING_CYCLE_TIME_INTERVAL
 static void init_serial(void);
 static ChannelOpt channel_for_encoder(EncoderIdx enc_idx);
 static Milliseconds calc_playhead_flash_time(Milliseconds clock_period);
-/// Set the param referenced by `idx` to `value`, and set its flags to indicate
-/// that it has been modified and needs to be written to the EEPROM.
-static inline void param_and_flags_set(Params *params, ParamIdx idx, uint8_t value);
-/// Read the bits specified in `mask`
-static inline uint8_t param_flags_get(const Params *params, ParamIdx idx, uint8_t mask);
-/// Set the bits specified in `mask` to 1, leaving the others untouched
-static inline void param_flags_set(Params *params, ParamIdx idx, uint8_t mask);
-/// Clear the bits specified in `mask` to 0, leaving the others untouched
-static inline void param_flags_clear(Params *params, ParamIdx idx, uint8_t mask);
-static void param_flags_clear_all_modified(Params *params, Mode mode);
 static void active_mode_switch(Mode mode);
 static void params_validate(Params *params, Mode mode);
 /// Load state for the given mode into `params`.
@@ -406,11 +396,6 @@ static ChannelOpt channel_for_encoder(EncoderIdx enc_idx) {
 	}
 }
 
-static inline void param_and_flags_set(Params *params, ParamIdx idx, uint8_t value) {
-	params->values[idx] = value;
-	param_flags_set(params, idx, (PARAM_FLAG_MODIFIED | PARAM_FLAG_NEEDS_WRITE));
-}
-
 static Milliseconds calc_playhead_flash_time(Milliseconds clock_period) {
 	// This is a standard "scale from input range to output range" function, but
 	// it uses specific ranges so that we can avoid multiplication or division by
@@ -428,24 +413,6 @@ static Milliseconds calc_playhead_flash_time(Milliseconds clock_period) {
 	// Add output min
 	result += 64;
 	return result;
-}
-
-static inline uint8_t param_flags_get(const Params *params, ParamIdx idx, uint8_t mask) {
-	return (params->flags[idx] & mask);
-}
-
-static inline void param_flags_set(Params *params, ParamIdx idx, uint8_t mask) { params->flags[idx] |= mask; }
-
-static inline void param_flags_clear(Params *params, ParamIdx idx, uint8_t mask) {
-	params->flags[idx] &= ~mask;
-}
-
-static void param_flags_clear_all_modified(Params *params, Mode mode) {
-	uint8_t num_params = mode_num_params[mode];
-
-	for (uint8_t idx = 0; idx < num_params; idx++) {
-		param_flags_clear(params, idx, PARAM_FLAG_MODIFIED);
-	}
 }
 
 static void active_mode_switch(Mode mode) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -38,6 +38,7 @@ static Timeout playhead_idle_loop_timeout = {.duration = PLAYHEAD_IDLE_LOOP_PERI
 
 static Timeout adjustment_display_timeout = {.duration = ADJUSTMENT_DISPLAY_TIME};
 
+#if !PARAM_TABLES
 typedef struct EuclideanChannelUpdate {
 	uint8_t length;
 	uint8_t density;
@@ -55,6 +56,7 @@ static const EuclideanChannelUpdate EUCLIDEAN_UPDATE_EMPTY = {
     .density_changed = false,
     .offset_changed = false,
 };
+#endif
 
 #define PARAM_FLAGS_NONE 0x0
 #define PARAM_FLAG_MODIFIED 0x1

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -97,7 +97,7 @@ static inline Address eeprom_addr_offset(Channel channel);
 static void log_input_events(const InputEvents *events);
 #endif
 #if LOGGING_ENABLED && PARAM_TABLES
-static void log_all_modified_params(Mode mode);
+static void log_all_modified_params(const Params *params, Mode mode);
 #endif
 
 /* MAIN */
@@ -536,7 +536,7 @@ void loop() {
 #endif
 
 #if LOGGING_ENABLED && PARAM_TABLES
-	log_all_modified_params(active_mode);
+	log_all_modified_params(&params, active_mode);
 #endif
 }
 
@@ -738,14 +738,14 @@ static void log_input_events(const InputEvents *events) {
 #endif
 
 #if LOGGING_ENABLED && PARAM_TABLES
-static void log_all_modified_params(Mode mode) {
+static void log_all_modified_params(const Params *params, Mode mode) {
 	uint8_t num_params = mode_num_params[mode];
 
 	for (uint8_t idx = 0; idx < num_params; idx++) {
-		bool modified = param_flags_get(&params, idx, PARAM_FLAG_MODIFIED);
+		bool modified = param_flags_get(params, idx, PARAM_FLAG_MODIFIED);
 		if (!modified) continue;
 
-		uint8_t val = params.values[idx];
+		uint8_t val = params->values[idx];
 		char name[PARAM_NAME_LEN];
 		param_name(name, mode, idx);
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -77,7 +77,7 @@ typedef struct ParamsRuntime {
 } ParamsRuntime;
 
 /// Stores the runtime information of the active mode's parameters.
-static ParamsRuntime params;
+static ParamsRuntime active_mode_params;
 
 #if LOGGING_ENABLED && LOGGING_CYCLE_TIME
 Microseconds cycle_time_max;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -89,10 +89,10 @@ static void eeprom_save_all_needing_write();
 #if !PARAM_TABLES
 /// Load state from EEPROM into the given `EuclideanState`
 static void eeprom_load(EuclideanState *s);
-#endif
 static inline Address eeprom_addr_length(Channel channel);
 static inline Address eeprom_addr_density(Channel channel);
 static inline Address eeprom_addr_offset(Channel channel);
+#endif
 #if LOGGING_ENABLED && LOGGING_INPUT
 static void log_input_events(const InputEvents *events);
 #endif
@@ -705,11 +705,13 @@ static void eeprom_load(EuclideanState *s) {
 }
 #endif
 
+#if !PARAM_TABLES
 static inline Address eeprom_addr_length(Channel channel) { return (channel * 2) + 1; }
 
 static inline Address eeprom_addr_density(Channel channel) { return (channel * 2) + 2; }
 
 static inline Address eeprom_addr_offset(Channel channel) { return channel + 7; }
+#endif
 
 #if LOGGING_ENABLED && LOGGING_INPUT
 static void log_input_events(const InputEvents *events) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -582,20 +582,21 @@ static void active_mode_validate() {
 
 static void euclid_params_validate() {
 	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
-		ParamIdx idx_length = euclid_param_idx((Channel)c, EUCLIDEAN_PARAM_LENGTH);
-		ParamIdx idx_density = euclid_param_idx((Channel)c, EUCLIDEAN_PARAM_DENSITY);
-		ParamIdx idx_offset = euclid_param_idx((Channel)c, EUCLIDEAN_PARAM_OFFSET);
-		uint8_t length = params.values[idx_length];
-		uint8_t density = params.values[idx_density];
-		uint8_t offset = params.values[idx_offset];
+		Channel channel = (Channel)c;
+		uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+		uint8_t density = euclid_param_get(channel, EUCLIDEAN_PARAM_DENSITY);
+		uint8_t offset = euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
+			ParamIdx idx_length = euclid_param_idx(channel, EUCLIDEAN_PARAM_LENGTH);
 			params.values[idx_length] = BEAT_LENGTH_DEFAULT;
 		}
 		if (density > BEAT_DENSITY_MAX || density > length) {
+			ParamIdx idx_density = euclid_param_idx(channel, EUCLIDEAN_PARAM_DENSITY);
 			params.values[idx_density] = BEAT_DENSITY_DEFAULT;
 		}
 		if (offset > BEAT_OFFSET_MAX || offset > length) {
+			ParamIdx idx_offset = euclid_param_idx(channel, EUCLIDEAN_PARAM_OFFSET);
 			params.values[idx_offset] = BEAT_OFFSET_DEFAULT;
 		}
 	}

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -97,7 +97,7 @@ static inline Address eeprom_addr_offset(Channel channel);
 #if LOGGING_ENABLED && LOGGING_INPUT
 static void log_input_events(const InputEvents *events);
 #endif
-#if LOGGING_ENABLED && LOGGING_EEPROM && PARAM_TABLES
+#if LOGGING_ENABLED && PARAM_TABLES
 static void log_all_modified_params();
 #endif
 
@@ -536,7 +536,7 @@ void loop() {
 	}
 #endif
 
-#if LOGGING_ENABLED && LOGGING_EEPROM && PARAM_TABLES
+#if LOGGING_ENABLED && PARAM_TABLES
 	log_all_modified_params();
 #endif
 }
@@ -671,6 +671,18 @@ static void eeprom_save_all_needing_write() {
 		uint8_t val = params.values[idx];
 		Address addr = param_address(mode, (ParamIdx)idx);
 		EEPROM.write(addr, val);
+
+#if LOGGING_ENABLED && LOGGING_EEPROM
+		char name[PARAM_NAME_LEN];
+		param_name(name, mode, idx);
+
+		Serial.print("EEPROM Write: ");
+		Serial.print(name);
+		Serial.print(" @");
+		Serial.print(addr);
+		Serial.print(": ");
+		Serial.println(val);
+#endif
 	}
 #endif
 }
@@ -725,7 +737,7 @@ static void log_input_events(const InputEvents *events) {
 }
 #endif
 
-#if LOGGING_ENABLED && LOGGING_EEPROM && PARAM_TABLES
+#if LOGGING_ENABLED && PARAM_TABLES
 static void log_all_modified_params() {
 	Mode mode = active_mode;
 	uint8_t num_params = mode_num_params[mode];
@@ -737,12 +749,9 @@ static void log_all_modified_params() {
 		uint8_t val = params.values[idx];
 		char name[PARAM_NAME_LEN];
 		param_name(name, mode, idx);
-		Address addr = param_address(mode, idx);
 
-		Serial.print("EEPROM Write: ");
+		Serial.print("Param ");
 		Serial.print(name);
-		Serial.print(" @");
-		Serial.print(addr);
 		Serial.print(": ");
 		Serial.println(val);
 	}

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -79,7 +79,6 @@ static inline uint8_t param_flags_get(ParamIdx idx, uint8_t mask);
 static inline void param_flags_set(ParamIdx idx, uint8_t mask);
 /// Clear the bits specified in `mask` to 0, leaving the others untouched
 static inline void param_flags_clear(ParamIdx idx, uint8_t mask);
-static inline void param_flags_set_modified_and_needs_write(ParamIdx idx);
 static void param_flags_clear_all_modified();
 static void active_mode_switch(Mode mode);
 static void active_mode_validate();
@@ -595,10 +594,6 @@ static inline uint8_t param_flags_get(ParamIdx idx, uint8_t mask) { return (para
 static inline void param_flags_set(ParamIdx idx, uint8_t mask) { params.flags[idx] |= mask; }
 
 static inline void param_flags_clear(ParamIdx idx, uint8_t mask) { params.flags[idx] &= ~mask; }
-
-static inline void param_flags_set_modified_and_needs_write(ParamIdx idx) {
-	param_flags_set(idx, (PARAM_FLAG_MODIFIED | PARAM_FLAG_NEEDS_WRITE));
-}
 
 static void param_flags_clear_all_modified() {
 	Mode mode = active_mode;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -58,30 +58,6 @@ static const EuclideanChannelUpdate EUCLIDEAN_UPDATE_EMPTY = {
 };
 #endif
 
-#define PARAM_FLAGS_NONE 0x0
-#define PARAM_FLAG_MODIFIED 0x1
-#define PARAM_FLAG_NEEDS_WRITE 0x2
-
-/// Maximum size of `ParamsRuntime`'s tables. Must be large enough to store the
-/// `ParamId` type for any mode.
-#define PARAMS_RUNTIME_MAX 9
-
-/// Parameter properties which need to be modified at runtime. Each table has
-/// the same length (`.len`), and they are indexed by a mode's associated
-/// `ParamId` type.
-typedef struct ParamsRuntime {
-	/// Number of elements in tables
-	uint8_t len;
-	/// List of parameter values of length `.len`. The values are always assumed to be in bounds.
-	uint8_t values[PARAMS_RUNTIME_MAX];
-	/// List of parameter properties, stored as bitflags, of length `.len`. Bitflags are indexed
-	/// via `PARAM_FLAG_*` defines.
-	uint8_t flags[PARAMS_RUNTIME_MAX];
-} ParamsRuntime;
-
-/// Stores the runtime information of the active mode's parameters.
-static ParamsRuntime params;
-
 static Mode active_mode = MODE_EUCLID;
 
 #if LOGGING_ENABLED && LOGGING_CYCLE_TIME
@@ -606,10 +582,10 @@ static void active_mode_validate() {
 static void euclid_params_validate() {
 	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
 		ParamIdx idx_length = euclid_param_idx((Channel)c, EUCLIDEAN_PARAM_LENGTH);
-		uint8_t length = params.values[idx_length];
 		ParamIdx idx_density = euclid_param_idx((Channel)c, EUCLIDEAN_PARAM_DENSITY);
-		uint8_t density = params.values[idx_density];
 		ParamIdx idx_offset = euclid_param_idx((Channel)c, EUCLIDEAN_PARAM_OFFSET);
+		uint8_t length = params.values[idx_length];
+		uint8_t density = params.values[idx_density];
 		uint8_t offset = params.values[idx_offset];
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -118,9 +118,10 @@ void setup() {
 
 	// Initialise generated rhythms
 	for (int a = 0; a < NUM_CHANNELS; a++) {
-		generated_rhythms[a] =
-		    euclidean_pattern_rotate(euclidean_state.channels[a].length, euclidean_state.channels[a].density,
-		                             euclidean_state.channels[a].offset);
+		uint8_t length = euclidean_state.channels[a].length;
+		uint8_t density = euclidean_state.channels[a].density;
+		uint8_t offset = euclidean_state.channels[a].offset;
+		generated_rhythms[a] = euclidean_pattern_rotate(length, density, offset);
 	}
 
 	led_wake();

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -85,7 +85,7 @@ static void params_validate(Params *params, Mode mode);
 static void euclid_params_validate(Params *params);
 /// Load state for the given mode into `params`.
 static void eeprom_params_load(Params *params, Mode mode);
-static void eeprom_save_all_needing_write(Mode mode);
+static void eeprom_save_all_needing_write(Params *params, Mode mode);
 #if !PARAM_TABLES
 /// Load state from EEPROM into the given `EuclideanState`
 static void eeprom_load(EuclideanState *s);
@@ -486,7 +486,7 @@ void loop() {
 	/* EEPROM WRITES */
 
 #if PARAM_TABLES
-	eeprom_save_all_needing_write(active_mode);
+	eeprom_save_all_needing_write(&params, active_mode);
 #endif
 
 #if EEPROM_WRITE && !PARAM_TABLES
@@ -656,17 +656,17 @@ static void eeprom_params_load(Params *params, Mode mode) {
 	params->len = num_params;
 }
 
-static void eeprom_save_all_needing_write(Mode mode) {
+static void eeprom_save_all_needing_write(Params *params, Mode mode) {
 #if EEPROM_WRITE
 	uint8_t num_params = mode_num_params[mode];
 
 	for (uint8_t idx = 0; idx < num_params; idx++) {
-		bool needs_write = param_flags_get(&params, idx, PARAM_FLAG_NEEDS_WRITE);
+		bool needs_write = param_flags_get(params, idx, PARAM_FLAG_NEEDS_WRITE);
 		if (!needs_write) continue;
 
-		param_flags_clear(&params, idx, PARAM_FLAG_NEEDS_WRITE);
+		param_flags_clear(params, idx, PARAM_FLAG_NEEDS_WRITE);
 
-		uint8_t val = params.values[idx];
+		uint8_t val = params->values[idx];
 		Address addr = param_address(mode, (ParamIdx)idx);
 		EEPROM.write(addr, val);
 

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -81,8 +81,8 @@ static inline void param_flags_set(ParamIdx idx, uint8_t mask);
 static inline void param_flags_clear(ParamIdx idx, uint8_t mask);
 static void param_flags_clear_all_modified();
 static void active_mode_switch(Mode mode);
-static void params_validate(Mode mode);
-static void euclid_params_validate();
+static void params_validate(ParamsRuntime *params, Mode mode);
+static void euclid_params_validate(ParamsRuntime *params);
 /// Load state for the given mode into `params`.
 static void eeprom_params_load(Mode mode);
 static void eeprom_save_all_needing_write();
@@ -607,32 +607,32 @@ static void param_flags_clear_all_modified() {
 static void active_mode_switch(Mode mode) {
 	active_mode = mode;
 	eeprom_params_load(mode);
-	params_validate(mode);
+	params_validate(&params, mode);
 }
 
-static void params_validate(Mode mode) {
+static void params_validate(ParamsRuntime *params, Mode mode) {
 	switch (mode) {
 		case MODE_EUCLID:
-			euclid_params_validate();
+			euclid_params_validate(params);
 			break;
 	}
 }
 
-static void euclid_params_validate() {
+static void euclid_params_validate(ParamsRuntime *params) {
 	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
 		Channel channel = (Channel)c;
-		uint8_t length = euclid_get_length(&params, channel);
-		uint8_t density = euclid_get_density(&params, channel);
-		uint8_t offset = euclid_get_offset(&params, channel);
+		uint8_t length = euclid_get_length(params, channel);
+		uint8_t density = euclid_get_density(params, channel);
+		uint8_t offset = euclid_get_offset(params, channel);
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
-			euclid_param_set(&params, channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
+			euclid_param_set(params, channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
 		}
 		if (density > BEAT_DENSITY_MAX || density > length) {
-			euclid_param_set(&params, channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
+			euclid_param_set(params, channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
 		}
 		if (offset > BEAT_OFFSET_MAX || offset > length) {
-			euclid_param_set(&params, channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
+			euclid_param_set(params, channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
 		}
 	}
 }

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -14,6 +14,7 @@
 #include "hardware/properties.h"
 #include "modes/clock.h"
 #include "modes/euclid.h"
+#include "params.h"
 #include "ui/active_channel.h"
 #include "ui/framebuffer.h"
 #include "ui/framebuffer_led.h"
@@ -62,7 +63,7 @@ static const EuclideanChannelUpdate EUCLIDEAN_UPDATE_EMPTY = {
 
 /// Maximum size of `ParamsRuntime`'s tables. Must be large enough to store the
 /// `ParamId` type for any mode.
-#define PARAMS_RUNTIME_MAX 10
+#define PARAMS_RUNTIME_MAX 9
 
 /// Parameter properties which need to be modified at runtime. Each table has
 /// the same length (`.len`), and they are indexed by a mode's associated
@@ -77,7 +78,7 @@ typedef struct ParamsRuntime {
 	uint8_t flags[PARAMS_RUNTIME_MAX];
 } ParamsRuntime;
 
-static ParamsRuntime params_runtime;
+static ParamsRuntime params;
 
 #if LOGGING_ENABLED && LOGGING_CYCLE_TIME
 Microseconds cycle_time_max;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -92,6 +92,12 @@ static Timeout log_cycle_time_timeout = {.duration = LOGGING_CYCLE_TIME_INTERVAL
 static void init_serial(void);
 static ChannelOpt channel_for_encoder(EncoderIdx enc_idx);
 static Milliseconds calc_playhead_flash_time(Milliseconds clock_period);
+/// Read the bits specified in `mask`
+static inline uint8_t params_flags_get(ParamIdx idx, uint8_t mask);
+/// Set the bits specified in `mask` to 1, leaving the others untouched
+static inline void params_flags_set(ParamIdx idx, uint8_t mask);
+/// Clear the bits specified in `mask` to 0, leaving the others untouched
+static inline void params_flags_clear(ParamIdx idx, uint8_t mask);
 static void active_mode_switch(Mode mode);
 static void active_mode_validate();
 static void euclid_params_validate();
@@ -521,6 +527,12 @@ static Milliseconds calc_playhead_flash_time(Milliseconds clock_period) {
 	result += 64;
 	return result;
 }
+
+static inline uint8_t params_flags_get(ParamIdx idx, uint8_t mask) { return (params.flags[idx] & mask); }
+
+static inline void params_flags_set(ParamIdx idx, uint8_t mask) { params.flags[idx] |= mask; }
+
+static inline void params_flags_clear(ParamIdx idx, uint8_t mask) { params.flags[idx] &= ~mask; }
 
 static void active_mode_switch(Mode mode) {
 	active_mode = mode;

--- a/src/Euclidean_Quiet.cpp
+++ b/src/Euclidean_Quiet.cpp
@@ -120,9 +120,16 @@ void setup() {
 
 	// Initialise generated rhythms
 	for (int a = 0; a < NUM_CHANNELS; a++) {
+#if PARAM_TABLES
+		Channel channel = (Channel)a;
+		uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+		uint8_t density = euclid_param_get(channel, EUCLIDEAN_PARAM_DENSITY);
+		uint8_t offset = euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
+#else
 		uint8_t length = euclidean_state.channels[a].length;
 		uint8_t density = euclidean_state.channels[a].density;
 		uint8_t offset = euclidean_state.channels[a].offset;
+#endif
 		generated_rhythms[a] = euclidean_pattern_rotate(length, density, offset);
 	}
 

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -13,6 +13,9 @@ typedef unsigned long Microseconds;
 /// Index into parameter tables.
 typedef uint8_t ParamIdx;
 
+/// Index into EEPROM memory
+typedef int Address;
+
 /// References one of the three channels
 typedef enum Channel {
 	CHANNEL_1,

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -5,9 +5,13 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef unsigned long Milliseconds;
 typedef unsigned long Microseconds;
+
+/// Index into parameter tables.
+typedef uint8_t ParamIdx;
 
 /// References one of the three channels
 typedef enum Channel {

--- a/src/config.h
+++ b/src/config.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /* DEBUG FEATURES */
 
-#define LOGGING_ENABLED 0 // 0 = Logging over serial disabled, 1 = enabled
+#define LOGGING_ENABLED 1 // 0 = Logging over serial disabled, 1 = enabled
 #define LOGGING_INPUT 0 // 0 = Don't log Input events, 1 = Log input events
 #define LOGGING_CH1_POSITION 0 // 0 = Don't log Channel 1 position updates, 1 = Log position updates
 #define LOGGING_EEPROM 0 // 0 = Don't log EEPROM writes, 1 = Log EEPROM writes

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,7 @@ extern "C" {
 #define INTERNAL_CLOCK_DEFAULT 0 // 0 = Internal clock begins disabled, 1 = begins enabled
 #define EEPROM_READ 1 // 0 = Reading from EEPROM disabled, 1 = enabled
 #define EEPROM_WRITE 1 // 0 = Writing to EEPROM disabled, 1 = enabled
+#define PARAM_TABLES 0 // 0 = Use state structs, 1 = Use param tables
 
 /* DEBUG FEATURES */
 

--- a/src/config.h
+++ b/src/config.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /* DEBUG FEATURES */
 
-#define LOGGING_ENABLED 1 // 0 = Logging over serial disabled, 1 = enabled
+#define LOGGING_ENABLED 0 // 0 = Logging over serial disabled, 1 = enabled
 #define LOGGING_INPUT 0 // 0 = Don't log Input events, 1 = Log input events
 #define LOGGING_CH1_POSITION 0 // 0 = Don't log Channel 1 position updates, 1 = Log position updates
 #define LOGGING_EEPROM 0 // 0 = Don't log EEPROM writes, 1 = Log EEPROM writes

--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,6 @@ extern "C" {
 #define INTERNAL_CLOCK_DEFAULT 0 // 0 = Internal clock begins disabled, 1 = begins enabled
 #define EEPROM_READ 1 // 0 = Reading from EEPROM disabled, 1 = enabled
 #define EEPROM_WRITE 1 // 0 = Writing to EEPROM disabled, 1 = enabled
-#define PARAM_TABLES 0 // 0 = Use state structs, 1 = Use param tables
 
 /* DEBUG FEATURES */
 

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -5,7 +5,7 @@
 
 /* GLOBALS */
 
-EuclideanState euclidean_state = {
+EuclidState euclid_state = {
     .channel_positions = {0, 0, 0},
     .sequencer_running = false,
 };
@@ -15,7 +15,7 @@ uint16_t generated_rhythms[NUM_CHANNELS];
 
 AdjustmentDisplayState adjustment_display_state = {
     .channel = CHANNEL_1,
-    .parameter = EUCLIDEAN_PARAM_LENGTH,
+    .parameter = EUCLID_PARAM_LENGTH,
     .visible = false,
 };
 
@@ -51,19 +51,19 @@ void euclid_params_validate(Params *params) {
 		uint8_t offset = euclid_get_offset(params, channel);
 
 		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
-			euclid_param_set(params, channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
+			euclid_param_set(params, channel, EUCLID_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
 		}
 		if (density > BEAT_DENSITY_MAX || density > length) {
-			euclid_param_set(params, channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
+			euclid_param_set(params, channel, EUCLID_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
 		}
 		if (offset > BEAT_OFFSET_MAX || offset > length) {
-			euclid_param_set(params, channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
+			euclid_param_set(params, channel, EUCLID_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
 		}
 	}
 }
 
-EuclideanParamOpt euclidean_param_opt(EuclideanParam inner) {
-	return (EuclideanParamOpt){.inner = inner, .valid = true};
+EuclidParamOpt euclid_param_opt(EuclidParam inner) {
+	return (EuclidParamOpt){.inner = inner, .valid = true};
 }
 
 uint8_t euclid_update(const InputEvents *events) {
@@ -96,27 +96,27 @@ void euclid_draw_channels(void) {
 static void sequencer_handle_reset() {
 	// Go to the first step for each channel
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
-		euclidean_state.channel_positions[channel] = 0;
+		euclid_state.channel_positions[channel] = 0;
 	}
 
 	// Stop the sequencer
-	euclidean_state.sequencer_running = false;
+	euclid_state.sequencer_running = false;
 }
 
 static void sequencer_handle_clock() {
 	// Advance sequencer if it is running
-	if (euclidean_state.sequencer_running) {
+	if (euclid_state.sequencer_running) {
 		// Only advance if sequencer is running
 		sequencer_advance();
 	} else {
 		// If sequencer is stopped, start it so that the next clock advances
-		euclidean_state.sequencer_running = true;
+		euclid_state.sequencer_running = true;
 	}
 }
 
 static void sequencer_advance() {
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
-		uint8_t position = euclidean_state.channel_positions[channel];
+		uint8_t position = euclid_state.channel_positions[channel];
 		uint8_t length = euclid_get_length(&params, channel);
 
 		// Move sequencer playhead to next step
@@ -124,7 +124,7 @@ static void sequencer_advance() {
 		if (position >= length) {
 			position = 0;
 		}
-		euclidean_state.channel_positions[channel] = position;
+		euclid_state.channel_positions[channel] = position;
 
 #if LOGGING_ENABLED && LOGGING_POSITION
 		if (channel == 0) {
@@ -140,7 +140,7 @@ static uint8_t sequencer_read_current_step() {
 
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		uint8_t length = euclid_get_length(&params, channel);
-		uint8_t position = euclidean_state.channel_positions[channel];
+		uint8_t position = euclid_state.channel_positions[channel];
 		uint16_t pattern = generated_rhythms[channel];
 
 		// Turn on LEDs on the bottom row for channels where the step is active
@@ -160,7 +160,7 @@ static uint8_t sequencer_read_current_step() {
 
 static inline void draw_channel(Channel channel) {
 	uint8_t length = euclid_get_length(&params, channel);
-	uint8_t position = euclidean_state.channel_positions[channel];
+	uint8_t position = euclid_state.channel_positions[channel];
 	uint16_t pattern = generated_rhythms[channel];
 
 	// Clear rows
@@ -170,7 +170,7 @@ static inline void draw_channel(Channel channel) {
 
 	bool showing_length_display = (adjustment_display_state.visible) &&
 	                              (channel == adjustment_display_state.channel) &&
-	                              (adjustment_display_state.parameter == EUCLIDEAN_PARAM_LENGTH);
+	                              (adjustment_display_state.parameter == EUCLID_PARAM_LENGTH);
 	if (showing_length_display) {
 		draw_channel_length(channel, pattern, length);
 	}

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -121,7 +121,11 @@ static void sequencer_handle_clock() {
 static void sequencer_advance() {
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
+#ifdef PARAM_TABLES
+		uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+#else
 		uint8_t length = channel_state.length;
+#endif
 		uint8_t position = channel_state.position;
 
 		// Move sequencer playhead to next step

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -121,7 +121,7 @@ static void sequencer_handle_clock() {
 static void sequencer_advance() {
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
-#ifdef PARAM_TABLES
+#if PARAM_TABLES
 		uint8_t length = euclid_param_get_length(channel);
 #else
 		uint8_t length = channel_state.length;
@@ -149,7 +149,7 @@ static uint8_t sequencer_read_current_step() {
 
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
-#ifdef PARAM_TABLES
+#if PARAM_TABLES
 		uint8_t length = euclid_param_get_length(channel);
 #else
 		uint8_t length = channel_state.length;

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -135,7 +135,7 @@ static void sequencer_advance() {
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 #if PARAM_TABLES
 		uint8_t position = euclidean_state.channel_positions[channel];
-		uint8_t length = euclid_param_get_length(channel);
+		uint8_t length = euclid_get_length(&params, channel);
 #else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 		uint8_t length = channel_state.length;
@@ -167,7 +167,7 @@ static uint8_t sequencer_read_current_step() {
 
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 #if PARAM_TABLES
-		uint8_t length = euclid_param_get_length(channel);
+		uint8_t length = euclid_get_length(&params, channel);
 		uint8_t position = euclidean_state.channel_positions[channel];
 #else
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
@@ -193,7 +193,7 @@ static uint8_t sequencer_read_current_step() {
 
 static inline void draw_channel(Channel channel) {
 #if PARAM_TABLES
-	uint8_t length = euclid_param_get_length(channel);
+	uint8_t length = euclid_get_length(&params, channel);
 	uint8_t position = euclidean_state.channel_positions[channel];
 #else
 	EuclideanChannelState channel_state = euclidean_state.channels[channel];

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -49,10 +49,6 @@ static bool pattern_read(uint16_t pattern, uint8_t length, uint8_t position);
 
 /* EXTERNAL */
 
-ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
-	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
-}
-
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner) {
 	return (EuclideanParamOpt){.inner = inner, .valid = true};
 }

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -49,6 +49,10 @@ static bool pattern_read(uint16_t pattern, uint8_t length, uint8_t position);
 
 /* EXTERNAL */
 
+ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
+	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
+}
+
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner) {
 	return (EuclideanParamOpt){.inner = inner, .valid = true};
 }

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -43,6 +43,25 @@ static bool pattern_read(uint16_t pattern, uint8_t length, uint8_t position);
 
 /* EXTERNAL */
 
+void euclid_params_validate(Params *params) {
+	for (uint8_t c = 0; c < NUM_CHANNELS; c++) {
+		Channel channel = (Channel)c;
+		uint8_t length = euclid_get_length(params, channel);
+		uint8_t density = euclid_get_density(params, channel);
+		uint8_t offset = euclid_get_offset(params, channel);
+
+		if ((length > BEAT_LENGTH_MAX) || (length < BEAT_LENGTH_MIN)) {
+			euclid_param_set(params, channel, EUCLIDEAN_PARAM_LENGTH, BEAT_LENGTH_DEFAULT);
+		}
+		if (density > BEAT_DENSITY_MAX || density > length) {
+			euclid_param_set(params, channel, EUCLIDEAN_PARAM_DENSITY, BEAT_DENSITY_DEFAULT);
+		}
+		if (offset > BEAT_OFFSET_MAX || offset > length) {
+			euclid_param_set(params, channel, EUCLIDEAN_PARAM_OFFSET, BEAT_OFFSET_DEFAULT);
+		}
+	}
+}
+
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner) {
 	return (EuclideanParamOpt){.inner = inner, .valid = true};
 }

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -6,7 +6,7 @@
 /* GLOBALS */
 
 EuclidState euclid_state = {
-    .channel_positions = {0, 0, 0},
+    .sequencer_positions = {0, 0, 0},
     .sequencer_running = false,
 };
 
@@ -96,7 +96,7 @@ void euclid_draw_channels(void) {
 static void sequencer_handle_reset() {
 	// Go to the first step for each channel
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
-		euclid_state.channel_positions[channel] = 0;
+		euclid_state.sequencer_positions[channel] = 0;
 	}
 
 	// Stop the sequencer
@@ -116,7 +116,7 @@ static void sequencer_handle_clock() {
 
 static void sequencer_advance() {
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
-		uint8_t position = euclid_state.channel_positions[channel];
+		uint8_t position = euclid_state.sequencer_positions[channel];
 		uint8_t length = euclid_get_length(&params, channel);
 
 		// Move sequencer playhead to next step
@@ -124,7 +124,7 @@ static void sequencer_advance() {
 		if (position >= length) {
 			position = 0;
 		}
-		euclid_state.channel_positions[channel] = position;
+		euclid_state.sequencer_positions[channel] = position;
 
 #if LOGGING_ENABLED && LOGGING_POSITION
 		if (channel == 0) {
@@ -140,7 +140,7 @@ static uint8_t sequencer_read_current_step() {
 
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		uint8_t length = euclid_get_length(&params, channel);
-		uint8_t position = euclid_state.channel_positions[channel];
+		uint8_t position = euclid_state.sequencer_positions[channel];
 		uint16_t pattern = generated_rhythms[channel];
 
 		// Turn on LEDs on the bottom row for channels where the step is active
@@ -160,7 +160,7 @@ static uint8_t sequencer_read_current_step() {
 
 static inline void draw_channel(Channel channel) {
 	uint8_t length = euclid_get_length(&params, channel);
-	uint8_t position = euclid_state.channel_positions[channel];
+	uint8_t position = euclid_state.sequencer_positions[channel];
 	uint16_t pattern = generated_rhythms[channel];
 
 	// Clear rows

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -122,7 +122,7 @@ static void sequencer_advance() {
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
 #ifdef PARAM_TABLES
-		uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+		uint8_t length = euclid_param_get_length(channel);
 #else
 		uint8_t length = channel_state.length;
 #endif
@@ -171,7 +171,7 @@ static uint8_t sequencer_read_current_step() {
 static inline void draw_channel(Channel channel) {
 	EuclideanChannelState channel_state = euclidean_state.channels[channel];
 #if PARAM_TABLES
-	uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+	uint8_t length = euclid_param_get_length(channel);
 #else
 	uint8_t length = channel_state.length;
 #endif

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -149,7 +149,11 @@ static uint8_t sequencer_read_current_step() {
 
 	for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
 		EuclideanChannelState channel_state = euclidean_state.channels[channel];
+#ifdef PARAM_TABLES
+		uint8_t length = euclid_param_get_length(channel);
+#else
 		uint8_t length = channel_state.length;
+#endif
 		uint8_t position = channel_state.position;
 		uint16_t pattern = generated_rhythms[channel];
 

--- a/src/modes/euclid.c
+++ b/src/modes/euclid.c
@@ -166,7 +166,11 @@ static uint8_t sequencer_read_current_step() {
 
 static inline void draw_channel(Channel channel) {
 	EuclideanChannelState channel_state = euclidean_state.channels[channel];
+#if PARAM_TABLES
+	uint8_t length = euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+#else
 	uint8_t length = channel_state.length;
+#endif
 	uint8_t position = channel_state.position;
 	uint16_t pattern = generated_rhythms[channel];
 

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -34,7 +34,21 @@ extern "C" {
 
 /* DATA STRUCTURES */
 
-/// A parameter of the Euclidean rhythm generator
+/// A parameter id for the Euclidean rhythm generator mode, which indexes into
+/// parameter tables.
+typedef enum EuclidParamId {
+	EUCLID_PARAM_ID_CH1_LENGTH,
+	EUCLID_PARAM_ID_CH1_DENSITY,
+	EUCLID_PARAM_ID_CH1_OFFSET,
+	EUCLID_PARAM_ID_CH2_LENGTH,
+	EUCLID_PARAM_ID_CH2_DENSITY,
+	EUCLID_PARAM_ID_CH2_OFFSET,
+	EUCLID_PARAM_ID_CH3_LENGTH,
+	EUCLID_PARAM_ID_CH3_DENSITY,
+	EUCLID_PARAM_ID_CH3_OFFSET,
+} EuclidParamId;
+
+/// The kind of a parameter for a channel of the Euclidean rhythm generator
 typedef enum EuclideanParam {
 	EUCLIDEAN_PARAM_LENGTH,
 	EUCLIDEAN_PARAM_DENSITY,
@@ -90,7 +104,7 @@ extern TimeoutOnce playhead_flash_timeout;
 /// Wrap the provided value as an occupied optional
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);
 
-// Returns bitflags storing which output channels will fire this cycle, indexed 
+// Returns bitflags storing which output channels will fire this cycle, indexed
 // by `OutputChannel`.
 uint8_t euclid_update(const InputEvents *events);
 

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -89,7 +89,9 @@ extern TimeoutOnce playhead_flash_timeout;
 /* EXTERNAL */
 
 /// Return the `ParamIdx` for a given a channel and param kind
-ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind);
+inline ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
+	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
+}
 
 /// Wrap the provided value as an occupied optional
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -103,33 +103,31 @@ inline ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
 	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
 }
 
-/// Get the value of the specified param. Do not use if Euclidean is not the
-/// active mode.
-inline uint8_t euclid_param_get(Channel channel, EuclideanParam kind) {
+inline uint8_t euclid_param_get(const ParamsRuntime *params, Channel channel, EuclideanParam kind) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
-	return params.values[idx];
+	return params->values[idx];
 }
 
 /// Set the value of the specified param. Do not use if Euclidean is not the
 /// active mode.
-inline void euclid_param_set(Channel channel, EuclideanParam kind, uint8_t val) {
+inline void euclid_param_set(ParamsRuntime *params, Channel channel, EuclideanParam kind, uint8_t val) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
-	params.values[idx] = val;
+	params->values[idx] = val;
 }
 
 /// Do not use if Euclidean is not the active mode.
-inline uint8_t euclid_param_get_length(Channel channel) {
-	return euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+inline uint8_t euclid_get_length(const ParamsRuntime *params, Channel channel) {
+	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_LENGTH);
 }
 
 /// Do not use if Euclidean is not the active mode.
-inline uint8_t euclid_param_get_density(Channel channel) {
-	return euclid_param_get(channel, EUCLIDEAN_PARAM_DENSITY);
+inline uint8_t euclid_get_density(const ParamsRuntime *params, Channel channel) {
+	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_DENSITY);
 }
 
 /// Do not use if Euclidean is not the active mode.
-inline uint8_t euclid_param_get_offset(Channel channel) {
-	return euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
+inline uint8_t euclid_get_offset(const ParamsRuntime *params, Channel channel) {
+	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_OFFSET);
 }
 
 /// Wrap the provided value as an occupied optional

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -37,41 +37,41 @@ extern "C" {
 /* DATA STRUCTURES */
 
 /// The kind of a parameter for a channel of the Euclidean rhythm generator
-typedef enum EuclideanParam {
-	EUCLIDEAN_PARAM_LENGTH,
-	EUCLIDEAN_PARAM_DENSITY,
-	EUCLIDEAN_PARAM_OFFSET,
-} EuclideanParam;
+typedef enum EuclidParam {
+	EUCLID_PARAM_LENGTH,
+	EUCLID_PARAM_DENSITY,
+	EUCLID_PARAM_OFFSET,
+} EuclidParam;
 
-/// Euclidean parameter that is wrapped as an optional value
-typedef struct EuclideanParamOpt {
-	EuclideanParam inner;
+/// Parameter for the Euclidean rhythm generator mode that is wrapped as an optional value
+typedef struct EuclidParamOpt {
+	EuclidParam inner;
 	bool valid;
-} EuclideanParamOpt;
+} EuclidParamOpt;
 
-static const EuclideanParamOpt EUCLIDEAN_PARAM_OPT_NONE = {.inner = EUCLIDEAN_PARAM_LENGTH, .valid = false};
+static const EuclidParamOpt EUCLID_PARAM_OPT_NONE = {.inner = EUCLID_PARAM_LENGTH, .valid = false};
 
-/// State of the entire Euclidean module
-typedef struct EuclideanState {
+/// State of the entire Euclidean rhythm generator mode
+typedef struct EuclidState {
 	/// Step index representing the playhead position for for each of this mode's
 	/// channels, indexed by `Channel` enum. Valid values are `0` to `15`.
 	uint8_t channel_positions[NUM_CHANNELS];
 	bool sequencer_running;
-} EuclideanState;
+} EuclidState;
 
 typedef struct AdjustmentDisplayState {
 	/// Which channel is currently showing its adjustment display. Only one
 	/// adjustment display can be visible at a time.
 	Channel channel;
 	/// The parameter that is being displayed in the adjustment display.
-	EuclideanParam parameter;
+	EuclidParam parameter;
 	/// Is the adjustment display showing currently
 	bool visible;
 } AdjustmentDisplayState;
 
 /* GLOBALS */
 
-extern EuclideanState euclidean_state;
+extern EuclidState euclid_state;
 extern uint16_t generated_rhythms[NUM_CHANNELS];
 extern AdjustmentDisplayState adjustment_display_state;
 extern TimeoutOnce playhead_flash_timeout;
@@ -80,41 +80,41 @@ extern Params params;
 /* EXTERNAL */
 
 /// Return the `ParamIdx` for a given a channel and param kind
-inline ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
+inline ParamIdx euclid_param_idx(Channel channel, EuclidParam kind) {
 	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
 }
 
-inline uint8_t euclid_param_get(const Params *params, Channel channel, EuclideanParam kind) {
+inline uint8_t euclid_param_get(const Params *params, Channel channel, EuclidParam kind) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
 	return params->values[idx];
 }
 
 /// Set the value of the specified param. Do not use if Euclidean is not the
 /// active mode.
-inline void euclid_param_set(Params *params, Channel channel, EuclideanParam kind, uint8_t val) {
+inline void euclid_param_set(Params *params, Channel channel, EuclidParam kind, uint8_t val) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
 	params->values[idx] = val;
 }
 
 /// Do not use if Euclidean is not the active mode.
 inline uint8_t euclid_get_length(const Params *params, Channel channel) {
-	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_LENGTH);
+	return euclid_param_get(params, channel, EUCLID_PARAM_LENGTH);
 }
 
 /// Do not use if Euclidean is not the active mode.
 inline uint8_t euclid_get_density(const Params *params, Channel channel) {
-	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_DENSITY);
+	return euclid_param_get(params, channel, EUCLID_PARAM_DENSITY);
 }
 
 /// Do not use if Euclidean is not the active mode.
 inline uint8_t euclid_get_offset(const Params *params, Channel channel) {
-	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_OFFSET);
+	return euclid_param_get(params, channel, EUCLID_PARAM_OFFSET);
 }
 
 void euclid_params_validate(Params *params);
 
 /// Wrap the provided value as an occupied optional
-EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);
+EuclidParamOpt euclid_param_opt(EuclidParam inner);
 
 // Returns bitflags storing which output channels will fire this cycle, indexed
 // by `OutputChannel`.

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -111,6 +111,8 @@ inline uint8_t euclid_get_offset(const Params *params, Channel channel) {
 	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_OFFSET);
 }
 
+void euclid_params_validate(Params *params);
+
 /// Wrap the provided value as an occupied optional
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);
 

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -51,30 +51,11 @@ typedef struct EuclideanParamOpt {
 
 static const EuclideanParamOpt EUCLIDEAN_PARAM_OPT_NONE = {.inner = EUCLIDEAN_PARAM_LENGTH, .valid = false};
 
-#if !PARAM_TABLES
-/// State of the Euclidean rhythm generator and sequencer for a single channel
-typedef struct EuclideanChannelState {
-	/// Number of steps in the Euclidean rhythm, 1-16
-	uint8_t length;
-	/// Number of active steps in the Euclidean rhythm, 1-16
-	uint8_t density;
-	/// Number of steps to rotate the Euclidean rhythm to the right, 1-16
-	uint8_t offset;
-	/// Step index representing the playhead position for this channel's sequencer, 0-15
-	uint8_t position;
-} EuclideanChannelState;
-#endif
-
 /// State of the entire Euclidean module
 typedef struct EuclideanState {
-#if PARAM_TABLES
 	/// Step index representing the playhead position for for each of this mode's
 	/// channels, indexed by `Channel` enum. Valid values are `0` to `15`.
 	uint8_t channel_positions[NUM_CHANNELS];
-#else
-	/// State for each of this module's channels, indexed by `Channel` enum.
-	EuclideanChannelState channels[NUM_CHANNELS];
-#endif
 	bool sequencer_running;
 } EuclideanState;
 
@@ -138,12 +119,6 @@ EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);
 uint8_t euclid_update(const InputEvents *events);
 
 void euclid_draw_channels(void);
-
-#if !PARAM_TABLES
-/// Keep the data in the state in bounds. Bounds excursions can happen when
-/// loading from the EEPROM.
-void euclid_validate_state(EuclideanState *s);
-#endif
 
 #ifdef __cplusplus
 }

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -95,11 +95,18 @@ inline ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
 	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
 }
 
-/// Get the value of the specified param. Returns garbage data if Euclidean is
-/// not the active mode.
+/// Get the value of the specified param. Do not use if Euclidean is not the
+/// active mode.
 inline uint8_t euclid_param_get(Channel channel, EuclideanParam kind) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
 	return params.values[idx];
+}
+
+/// Set the value of the specified param. Do not use if Euclidean is not the
+/// active mode.
+inline void euclid_param_set(Channel channel, EuclideanParam kind, uint8_t val) {
+	ParamIdx idx = euclid_param_idx(channel, kind);
+	params.values[idx] = val;
 }
 
 /// Wrap the provided value as an occupied optional

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -34,20 +34,6 @@ extern "C" {
 
 /* DATA STRUCTURES */
 
-/// A parameter id for the Euclidean rhythm generator mode, which indexes into
-/// parameter tables.
-typedef enum EuclidParamId {
-	EUCLID_PARAM_ID_CH1_LENGTH,
-	EUCLID_PARAM_ID_CH1_DENSITY,
-	EUCLID_PARAM_ID_CH1_OFFSET,
-	EUCLID_PARAM_ID_CH2_LENGTH,
-	EUCLID_PARAM_ID_CH2_DENSITY,
-	EUCLID_PARAM_ID_CH2_OFFSET,
-	EUCLID_PARAM_ID_CH3_LENGTH,
-	EUCLID_PARAM_ID_CH3_DENSITY,
-	EUCLID_PARAM_ID_CH3_OFFSET,
-} EuclidParamId;
-
 /// The kind of a parameter for a channel of the Euclidean rhythm generator
 typedef enum EuclideanParam {
 	EUCLIDEAN_PARAM_LENGTH,

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -51,6 +51,7 @@ typedef struct EuclideanParamOpt {
 
 static const EuclideanParamOpt EUCLIDEAN_PARAM_OPT_NONE = {.inner = EUCLIDEAN_PARAM_LENGTH, .valid = false};
 
+#if !PARAM_TABLES
 /// State of the Euclidean rhythm generator and sequencer for a single channel
 typedef struct EuclideanChannelState {
 	/// Number of steps in the Euclidean rhythm, 1-16
@@ -62,11 +63,18 @@ typedef struct EuclideanChannelState {
 	/// Step index representing the playhead position for this channel's sequencer, 0-15
 	uint8_t position;
 } EuclideanChannelState;
+#endif
 
 /// State of the entire Euclidean module
 typedef struct EuclideanState {
+#if PARAM_TABLES
+	/// Step index representing the playhead position for for each of this mode's
+	/// channels, indexed by `Channel` enum. Valid values are `0` to `15`.
+	uint8_t channel_positions[NUM_CHANNELS];
+#else
 	/// State for each of this module's channels, indexed by `Channel` enum.
 	EuclideanChannelState channels[NUM_CHANNELS];
+#endif
 	bool sequencer_running;
 } EuclideanState;
 
@@ -133,9 +141,11 @@ uint8_t euclid_update(const InputEvents *events);
 
 void euclid_draw_channels(void);
 
+#if !PARAM_TABLES
 /// Keep the data in the state in bounds. Bounds excursions can happen when
 /// loading from the EEPROM.
 void euclid_validate_state(EuclideanState *s);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -55,7 +55,7 @@ static const EuclidParamOpt EUCLID_PARAM_OPT_NONE = {.inner = EUCLID_PARAM_LENGT
 typedef struct EuclidState {
 	/// Step index representing the playhead position for for each of this mode's
 	/// channels, indexed by `Channel` enum. Valid values are `0` to `15`.
-	uint8_t channel_positions[NUM_CHANNELS];
+	uint8_t sequencer_positions[NUM_CHANNELS];
 	bool sequencer_running;
 } EuclidState;
 

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -94,7 +94,7 @@ extern EuclideanState euclidean_state;
 extern uint16_t generated_rhythms[NUM_CHANNELS];
 extern AdjustmentDisplayState adjustment_display_state;
 extern TimeoutOnce playhead_flash_timeout;
-extern ParamsRuntime params;
+extern Params params;
 
 /* EXTERNAL */
 
@@ -103,30 +103,30 @@ inline ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
 	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
 }
 
-inline uint8_t euclid_param_get(const ParamsRuntime *params, Channel channel, EuclideanParam kind) {
+inline uint8_t euclid_param_get(const Params *params, Channel channel, EuclideanParam kind) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
 	return params->values[idx];
 }
 
 /// Set the value of the specified param. Do not use if Euclidean is not the
 /// active mode.
-inline void euclid_param_set(ParamsRuntime *params, Channel channel, EuclideanParam kind, uint8_t val) {
+inline void euclid_param_set(Params *params, Channel channel, EuclideanParam kind, uint8_t val) {
 	ParamIdx idx = euclid_param_idx(channel, kind);
 	params->values[idx] = val;
 }
 
 /// Do not use if Euclidean is not the active mode.
-inline uint8_t euclid_get_length(const ParamsRuntime *params, Channel channel) {
+inline uint8_t euclid_get_length(const Params *params, Channel channel) {
 	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_LENGTH);
 }
 
 /// Do not use if Euclidean is not the active mode.
-inline uint8_t euclid_get_density(const ParamsRuntime *params, Channel channel) {
+inline uint8_t euclid_get_density(const Params *params, Channel channel) {
 	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_DENSITY);
 }
 
 /// Do not use if Euclidean is not the active mode.
-inline uint8_t euclid_get_offset(const ParamsRuntime *params, Channel channel) {
+inline uint8_t euclid_get_offset(const Params *params, Channel channel) {
 	return euclid_param_get(params, channel, EUCLIDEAN_PARAM_OFFSET);
 }
 

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -109,6 +109,21 @@ inline void euclid_param_set(Channel channel, EuclideanParam kind, uint8_t val) 
 	params.values[idx] = val;
 }
 
+/// Do not use if Euclidean is not the active mode.
+inline uint8_t euclid_param_get_length(Channel channel) {
+	return euclid_param_get(channel, EUCLIDEAN_PARAM_LENGTH);
+}
+
+/// Do not use if Euclidean is not the active mode.
+inline uint8_t euclid_param_get_density(Channel channel) {
+	return euclid_param_get(channel, EUCLIDEAN_PARAM_DENSITY);
+}
+
+/// Do not use if Euclidean is not the active mode.
+inline uint8_t euclid_param_get_offset(Channel channel) {
+	return euclid_param_get(channel, EUCLIDEAN_PARAM_OFFSET);
+}
+
 /// Wrap the provided value as an occupied optional
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);
 

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -14,6 +14,7 @@ extern "C" {
 /* CONSTANTS */
 
 #define NUM_CHANNELS 3
+#define EUCLID_PARAMS_PER_CHANNEL 3
 
 // Bounds for three channel parameters
 // N: Beat Length
@@ -86,6 +87,9 @@ extern AdjustmentDisplayState adjustment_display_state;
 extern TimeoutOnce playhead_flash_timeout;
 
 /* EXTERNAL */
+
+/// Return the `ParamIdx` for a given a channel and param kind
+ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind);
 
 /// Wrap the provided value as an occupied optional
 EuclideanParamOpt euclidean_param_opt(EuclideanParam inner);

--- a/src/modes/euclid.h
+++ b/src/modes/euclid.h
@@ -7,6 +7,7 @@ extern "C" {
 #include "common/events.h"
 #include "common/timeout.h"
 #include "common/types.h"
+#include "params.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -85,12 +86,20 @@ extern EuclideanState euclidean_state;
 extern uint16_t generated_rhythms[NUM_CHANNELS];
 extern AdjustmentDisplayState adjustment_display_state;
 extern TimeoutOnce playhead_flash_timeout;
+extern ParamsRuntime params;
 
 /* EXTERNAL */
 
 /// Return the `ParamIdx` for a given a channel and param kind
 inline ParamIdx euclid_param_idx(Channel channel, EuclideanParam kind) {
 	return (ParamIdx)((channel * EUCLID_PARAMS_PER_CHANNEL) + kind);
+}
+
+/// Get the value of the specified param. Returns garbage data if Euclidean is
+/// not the active mode.
+inline uint8_t euclid_param_get(Channel channel, EuclideanParam kind) {
+	ParamIdx idx = euclid_param_idx(channel, kind);
+	return params.values[idx];
 }
 
 /// Wrap the provided value as an occupied optional

--- a/src/params.c
+++ b/src/params.c
@@ -1,9 +1,11 @@
 #include "params.h"
 /* CONSTANTS */
 
+#if LOGGING_ENABLED
 static const char name_not_found[PARAM_NAME_LEN] = "??";
+#endif
 
-/* GLBOALS */
+/* GLOBALS */
 
 Params params;
 
@@ -20,10 +22,12 @@ Channel 3: length = 5 density = 6 offset = 9
 /// backwards-compatibility with the original Sebsongs Euclidean firmware.
 static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4, 8, 5, 6, 9};
 
+#if LOGGING_ENABLED
 /// Table of parameter names for logging in the Euclid mode
 static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
     "L1", "D1", "O1", "L2", "D2", "O2", "L3", "D3", "O3",
 };
+#endif
 
 /* EXTERNAL */
 

--- a/src/params.c
+++ b/src/params.c
@@ -15,9 +15,12 @@ bool param_name(char *result, Mode mode, ParamIdx idx) {
 	if (!result) return false;
 
 	switch (mode) {
-		case MODE_EUCLID:
+		case MODE_EUCLID: {
+			if (idx >= EUCLID_NUM_PARAMS) {
+				return false;
+			}
 			memcpy(result, euclid_param_names[idx], PARAM_NAME_LEN);
-			break;
+		} break;
 	}
 
 	return true;

--- a/src/params.c
+++ b/src/params.c
@@ -31,6 +31,27 @@ static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 
 /* EXTERNAL */
 
+void param_and_flags_set(Params *params, ParamIdx idx, uint8_t value) {
+	params->values[idx] = value;
+	param_flags_set(params, idx, (PARAM_FLAG_MODIFIED | PARAM_FLAG_NEEDS_WRITE));
+}
+
+uint8_t param_flags_get(const Params *params, ParamIdx idx, uint8_t mask) {
+	return (params->flags[idx] & mask);
+}
+
+void param_flags_set(Params *params, ParamIdx idx, uint8_t mask) { params->flags[idx] |= mask; }
+
+void param_flags_clear(Params *params, ParamIdx idx, uint8_t mask) { params->flags[idx] &= ~mask; }
+
+void param_flags_clear_all_modified(Params *params, Mode mode) {
+	uint8_t num_params = mode_num_params[mode];
+
+	for (uint8_t idx = 0; idx < num_params; idx++) {
+		param_flags_clear(params, idx, PARAM_FLAG_MODIFIED);
+	}
+}
+
 Address param_address(Mode mode, ParamIdx idx) {
 	Address result = 0;
 	switch (mode) {

--- a/src/params.c
+++ b/src/params.c
@@ -5,7 +5,7 @@ static const char name_not_found[PARAM_NAME_LEN] = "??";
 
 /* GLBOALS */
 
-ParamsRuntime params;
+Params params;
 
 /* EXTERNAL */
 

--- a/src/params.c
+++ b/src/params.c
@@ -1,0 +1,18 @@
+#include "params.h"
+
+Address param_address(Mode mode, ParamIdx idx) {
+	Address result = 0;
+	switch (mode) {
+		case MODE_EUCLID:
+			result = euclid_param_addresses[idx];
+			break;
+	}
+	return result;
+}
+
+bool param_name(char *result, Mode mode, ParamIdx idx) {
+	if (!result) return false;
+
+	memcpy(result, param_names[idx], PARAM_NAME_LEN);
+	return true;
+}

--- a/src/params.c
+++ b/src/params.c
@@ -1,6 +1,13 @@
 #include "params.h"
+/* CONSTANTS */
 
 static const char name_not_found[PARAM_NAME_LEN] = "??";
+
+/* GLBOALS */
+
+ParamsRuntime params;
+
+/* EXTERNAL */
 
 Address param_address(Mode mode, ParamIdx idx) {
 	Address result = 0;

--- a/src/params.c
+++ b/src/params.c
@@ -10,9 +10,11 @@ Address param_address(Mode mode, ParamIdx idx) {
 	return result;
 }
 
+#if LOGGING_ENABLED
 bool param_name(char *result, Mode mode, ParamIdx idx) {
 	if (!result) return false;
 
 	memcpy(result, param_names[idx], PARAM_NAME_LEN);
 	return true;
 }
+#endif

--- a/src/params.c
+++ b/src/params.c
@@ -16,7 +16,7 @@ bool param_name(char *result, Mode mode, ParamIdx idx) {
 
 	switch (mode) {
 		case MODE_EUCLID:
-			memcpy(result, param_names[idx], PARAM_NAME_LEN);
+			memcpy(result, euclid_param_names[idx], PARAM_NAME_LEN);
 			break;
 	}
 

--- a/src/params.c
+++ b/src/params.c
@@ -1,5 +1,7 @@
 #include "params.h"
 
+static const char name_not_found[PARAM_NAME_LEN] = "??";
+
 Address param_address(Mode mode, ParamIdx idx) {
 	Address result = 0;
 	switch (mode) {
@@ -11,18 +13,15 @@ Address param_address(Mode mode, ParamIdx idx) {
 }
 
 #if LOGGING_ENABLED
-bool param_name(char *result, Mode mode, ParamIdx idx) {
-	if (!result) return false;
+void param_name(char *result, Mode mode, ParamIdx idx) {
+	// Early return - null pointer
+	if (!result) return;
 
 	switch (mode) {
 		case MODE_EUCLID: {
-			if (idx >= EUCLID_NUM_PARAMS) {
-				return false;
-			}
-			memcpy(result, euclid_param_names[idx], PARAM_NAME_LEN);
+			const char *name_source = (idx < EUCLID_NUM_PARAMS) ? euclid_param_names[idx] : name_not_found;
+			memcpy(result, name_source, PARAM_NAME_LEN);
 		} break;
 	}
-
-	return true;
 }
 #endif

--- a/src/params.c
+++ b/src/params.c
@@ -7,6 +7,24 @@ static const char name_not_found[PARAM_NAME_LEN] = "??";
 
 Params params;
 
+/* INTERNAL */
+
+/*
+Original EEPROM Schema:
+Channel 1: length = 1 density = 2 offset = 7
+Channel 2: length = 3 density = 4 offset = 8
+Channel 3: length = 5 density = 6 offset = 9
+*/
+
+/// EEPROM addresses for Euclidean mode params. The order is this way for
+/// backwards-compatibility with the original Sebsongs Euclidean firmware.
+static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4, 8, 5, 6, 9};
+
+/// Table of parameter names for logging in the Euclid mode
+static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
+    "L1", "D1", "O1", "L2", "D2", "O2", "L3", "D3", "O3",
+};
+
 /* EXTERNAL */
 
 Address param_address(Mode mode, ParamIdx idx) {

--- a/src/params.c
+++ b/src/params.c
@@ -14,7 +14,12 @@ Address param_address(Mode mode, ParamIdx idx) {
 bool param_name(char *result, Mode mode, ParamIdx idx) {
 	if (!result) return false;
 
-	memcpy(result, param_names[idx], PARAM_NAME_LEN);
+	switch (mode) {
+		case MODE_EUCLID:
+			memcpy(result, param_names[idx], PARAM_NAME_LEN);
+			break;
+	}
+
 	return true;
 }
 #endif

--- a/src/params.c
+++ b/src/params.c
@@ -30,9 +30,11 @@ static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 Address param_address(Mode mode, ParamIdx idx) {
 	Address result = 0;
 	switch (mode) {
-		case MODE_EUCLID:
-			result = euclid_param_addresses[idx];
-			break;
+		case MODE_EUCLID: {
+			if (idx < EUCLID_NUM_PARAMS) {
+				result = euclid_param_addresses[idx];
+			}
+		} break;
 	}
 	return result;
 }

--- a/src/params.h
+++ b/src/params.h
@@ -17,7 +17,7 @@ typedef enum Mode {
 #define EUCLID_NUM_PARAMS 9
 
 /// How many params this mode has. Indexed by the `Mode` enum.
-static const uint8_t mode_param_count[NUM_MODES] = {
+static const uint8_t mode_param_num[NUM_MODES] = {
     EUCLID_NUM_PARAMS, // EUCLID
 };
 

--- a/src/params.h
+++ b/src/params.h
@@ -9,20 +9,6 @@ extern "C" {
 #define EUCLID_PARAMS_NUM 9
 #define EUCLID_PARAMS_OFFSET 0
 
-/// A parameter id for the Euclidean rhythm generator mode, which indexes into
-/// parameter tables.
-typedef enum EuclidParamId {
-	EUCLID_PARAM_ID_CH1_LENGTH,
-	EUCLID_PARAM_ID_CH1_DENSITY,
-	EUCLID_PARAM_ID_CH1_OFFSET,
-	EUCLID_PARAM_ID_CH2_LENGTH,
-	EUCLID_PARAM_ID_CH2_DENSITY,
-	EUCLID_PARAM_ID_CH2_OFFSET,
-	EUCLID_PARAM_ID_CH3_LENGTH,
-	EUCLID_PARAM_ID_CH3_DENSITY,
-	EUCLID_PARAM_ID_CH3_OFFSET,
-} EuclidParamId;
-
 #define PARAMS_TOTAL 9
 
 // clang-format off

--- a/src/params.h
+++ b/src/params.h
@@ -52,26 +52,11 @@ typedef struct Params {
 /// Static information, such as addresses or names, is stored separately.
 extern Params params;
 
-/*
-Original EEPROM Schema:
-Channel 1: length = 1 density = 2 offset = 7
-Channel 2: length = 3 density = 4 offset = 8
-Channel 3: length = 5 density = 6 offset = 9
-*/
-
-/// EEPROM addresses for Euclidean mode params. The order is this way for
-/// backwards-compatibility with the original Sebsongs Euclidean firmware.
-static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4, 8, 5, 6, 9};
-
 Address param_address(Mode mode, ParamIdx idx);
 
 #if LOGGING_ENABLED
 
 #define PARAM_NAME_LEN 3
-/// Table of parameter names for logging in the Euclid mode
-static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
-    "L1", "D1", "O1", "L2", "D2", "O2", "L3", "D3", "O3",
-};
 
 /// @brief Retrieve the name for the specified parameter and store that name in
 /// the `result` null-terminated string.

--- a/src/params.h
+++ b/src/params.h
@@ -9,6 +9,11 @@ extern "C" {
 
 #include <stdint.h>
 
+/* Parameters are variables (stored as individual bytes) which are
+ * programmatically tracked, read from and written to EEPROM, and logged. Each
+ * mode has multiple parameters, in addition to its ephemeral state.
+ */
+
 #define NUM_MODES 1
 typedef enum Mode {
 	MODE_EUCLID,

--- a/src/params.h
+++ b/src/params.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "config.h"
 
 #include <stdint.h>
+#include <string.h>
 
 /* Parameters are variables (stored as individual bytes) which are
  * programmatically tracked, read from and written to EEPROM, and logged. Each
@@ -26,6 +27,30 @@ static const uint8_t mode_num_params[NUM_MODES] = {
     EUCLID_NUM_PARAMS, // EUCLID
 };
 
+#define PARAM_FLAGS_NONE 0x0
+#define PARAM_FLAG_MODIFIED 0x1
+#define PARAM_FLAG_NEEDS_WRITE 0x2
+
+/// Maximum size of `ParamsRuntime`'s tables. Must be large enough to store the
+/// `ParamId` type for any mode.
+#define PARAMS_RUNTIME_MAX 9
+
+/// Parameter properties which need to be modified at runtime. Each table has
+/// the same length (`.len`), and they are indexed by a mode's associated
+/// `ParamId` type.
+typedef struct ParamsRuntime {
+	/// Number of elements in tables
+	uint8_t len;
+	/// List of parameter values of length `.len`. The values are always assumed to be in bounds.
+	uint8_t values[PARAMS_RUNTIME_MAX];
+	/// List of parameter properties, stored as bitflags, of length `.len`. Bitflags are indexed
+	/// via `PARAM_FLAG_*` defines.
+	uint8_t flags[PARAMS_RUNTIME_MAX];
+} ParamsRuntime;
+
+/// Stores the runtime information of the active mode's parameters.
+ParamsRuntime params;
+
 /*
 Original EEPROM Schema:
 Channel 1: length = 1 density = 2 offset = 7
@@ -37,15 +62,7 @@ Channel 3: length = 5 density = 6 offset = 9
 /// backwards-compatibility with the original Sebsongs Euclidean firmware.
 static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4, 8, 5, 6, 9};
 
-Address param_address(Mode mode, ParamIdx idx) {
-	Address result = 0;
-	switch (mode) {
-		case MODE_EUCLID:
-			result = euclid_param_addresses[idx];
-			break;
-	}
-	return result;
-}
+Address param_address(Mode mode, ParamIdx idx);
 
 // clang-format off
 #if LOGGING_ENABLED
@@ -66,12 +83,7 @@ static const char param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 };
 
 // TODO: This implementation is brittle and will not scale with more modes. 
-bool param_name(char *result, Mode mode, ParamIdx idx) {
-	if (!result) return false;
-
-	memcpy(result, param_names[idx], PARAM_NAME_LEN);	
-	return true;
-}
+bool param_name(char *result, Mode mode, ParamIdx idx);
 
 #endif
 // clang-format on

--- a/src/params.h
+++ b/src/params.h
@@ -22,7 +22,7 @@ typedef enum Mode {
 #define EUCLID_NUM_PARAMS 9
 
 /// How many params this mode has. Indexed by the `Mode` enum.
-static const uint8_t mode_param_num[NUM_MODES] = {
+static const uint8_t mode_num_params[NUM_MODES] = {
     EUCLID_NUM_PARAMS, // EUCLID
 };
 

--- a/src/params.h
+++ b/src/params.h
@@ -7,19 +7,26 @@ extern "C" {
 #include "common/types.h"
 #include "config.h"
 
-#define EUCLID_PARAMS_NUM 9
-#define EUCLID_PARAMS_OFFSET 0
+#include <stdint.h>
 
-#define PARAMS_TOTAL 9
-
+#define NUM_MODES 1
 typedef enum Mode {
 	MODE_EUCLID,
 } Mode;
 
+#define EUCLID_NUM_PARAMS 9
+
+/// How many params this mode has. Indexed by the `Mode` enum.
+static const uint8_t mode_param_count[NUM_MODES] = {
+    EUCLID_NUM_PARAMS, // EUCLID
+};
+
 // clang-format off
 #if LOGGING_ENABLED
+
+#define PARAM_NAME_LEN 3
 /// Table of parameter names for logging
-static const char param_names[PARAMS_TOTAL][3] = {
+static const char param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 	// Euclid Mode
 	"L1", // Length, Channel 1
 	"D1", // Density, Channel 1
@@ -32,8 +39,12 @@ static const char param_names[PARAMS_TOTAL][3] = {
 	"O3",
 };
 
-void param_name(char *result, Mode mode, ParamIdx idx) {
-	strcpy(result, param_names[idx]);	
+// TODO: This implementation is brittle and will not scale with more modes. 
+bool param_name(char *result, Mode mode, ParamIdx idx) {
+	if (!result) return false;
+
+	memcpy(result, param_names[idx], PARAM_NAME_LEN);	
+	return true;
 }
 
 #endif

--- a/src/params.h
+++ b/src/params.h
@@ -21,6 +21,20 @@ static const uint8_t mode_param_num[NUM_MODES] = {
     EUCLID_NUM_PARAMS, // EUCLID
 };
 
+/// EEPROM addresses for Euclidean mode params. The order is this way for
+/// backwards-compatibility with the original Sebsongs Euclidean firmware.
+static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4, 8, 5, 6, 9};
+
+Address param_address(Mode mode, ParamIdx idx) {
+	Address result = 0;
+	switch (mode) {
+		case MODE_EUCLID:
+			result = euclid_param_addresses[idx];
+			break;
+	}
+	return result;
+}
+
 // clang-format off
 #if LOGGING_ENABLED
 

--- a/src/params.h
+++ b/src/params.h
@@ -48,8 +48,8 @@ typedef struct ParamsRuntime {
 	uint8_t flags[PARAMS_RUNTIME_MAX];
 } ParamsRuntime;
 
-/// Stores the runtime information of the active mode's parameters.
-ParamsRuntime params;
+/// Stores the runtime information for the active mode's parameters.
+extern ParamsRuntime params;
 
 /*
 Original EEPROM Schema:

--- a/src/params.h
+++ b/src/params.h
@@ -68,9 +68,8 @@ Address param_address(Mode mode, ParamIdx idx);
 #if LOGGING_ENABLED
 
 #define PARAM_NAME_LEN 3
-/// Table of parameter names for logging
-static const char param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
-	// Euclid Mode
+/// Table of parameter names for logging in the Euclid mode
+static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 	"L1", // Length, Channel 1
 	"D1", // Density, Channel 1
 	"O1", // Offset, Channel 1
@@ -82,7 +81,6 @@ static const char param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 	"O3",
 };
 
-// TODO: This implementation is brittle and will not scale with more modes. 
 bool param_name(char *result, Mode mode, ParamIdx idx);
 
 #endif

--- a/src/params.h
+++ b/src/params.h
@@ -81,6 +81,12 @@ static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
 	"O3",
 };
 
+/// @brief Calculate or look up the name for the specified parameter and store
+/// that name in the `result` null-terminated string.
+/// @param result A `char` array that can hold at least `PARAM_NAME_LEN` elements.
+/// @param mode The mode for the parameter
+/// @param idx The index of the parameter in the parameter tables
+/// @return `true` if the name for the parameter was found 
 bool param_name(char *result, Mode mode, ParamIdx idx);
 
 #endif

--- a/src/params.h
+++ b/src/params.h
@@ -1,0 +1,49 @@
+#ifndef PARAMS_H_
+#define PARAMS_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "config.h"
+
+#define EUCLID_PARAMS_NUM 9
+#define EUCLID_PARAMS_OFFSET 0
+
+/// A parameter id for the Euclidean rhythm generator mode, which indexes into
+/// parameter tables.
+typedef enum EuclidParamId {
+	EUCLID_PARAM_ID_CH1_LENGTH,
+	EUCLID_PARAM_ID_CH1_DENSITY,
+	EUCLID_PARAM_ID_CH1_OFFSET,
+	EUCLID_PARAM_ID_CH2_LENGTH,
+	EUCLID_PARAM_ID_CH2_DENSITY,
+	EUCLID_PARAM_ID_CH2_OFFSET,
+	EUCLID_PARAM_ID_CH3_LENGTH,
+	EUCLID_PARAM_ID_CH3_DENSITY,
+	EUCLID_PARAM_ID_CH3_OFFSET,
+} EuclidParamId;
+
+#define PARAMS_TOTAL 9
+
+// clang-format off
+#if LOGGING_ENABLED
+/// Table of parameter names for logging
+static const char params_names[PARAMS_TOTAL][3] = {
+	// Euclid Mode
+	"L1", // Length, Channel 1
+	"D1", // Density, Channel 1
+	"O1", // Offset, Channel 1
+	"L2",
+	"D2",
+	"O2",
+	"L3",
+	"D3",
+	"O3",
+};
+#endif
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PARAMS_H_ */

--- a/src/params.h
+++ b/src/params.h
@@ -64,33 +64,24 @@ static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4,
 
 Address param_address(Mode mode, ParamIdx idx);
 
-// clang-format off
 #if LOGGING_ENABLED
 
 #define PARAM_NAME_LEN 3
 /// Table of parameter names for logging in the Euclid mode
 static const char euclid_param_names[EUCLID_NUM_PARAMS][PARAM_NAME_LEN] = {
-	"L1", // Length, Channel 1
-	"D1", // Density, Channel 1
-	"O1", // Offset, Channel 1
-	"L2",
-	"D2",
-	"O2",
-	"L3",
-	"D3",
-	"O3",
+    "L1", "D1", "O1", "L2", "D2", "O2", "L3", "D3", "O3",
 };
 
-/// @brief Calculate or look up the name for the specified parameter and store
-/// that name in the `result` null-terminated string.
-/// @param result A `char` array that can hold at least `PARAM_NAME_LEN` elements.
+/// @brief Retrieve the name for the specified parameter and store that name in
+/// the `result` null-terminated string.
+/// @param result A `char` array that can hold at least `PARAM_NAME_LEN`
+/// elements. Will have the parameter name stored in it as a null-terminated
+/// string, or a placeholder if the param name can't be found.
 /// @param mode The mode for the parameter
 /// @param idx The index of the parameter in the parameter tables
-/// @return `true` if the name for the parameter was found 
-bool param_name(char *result, Mode mode, ParamIdx idx);
+void param_name(char *result, Mode mode, ParamIdx idx);
 
 #endif
-// clang-format on
 
 #ifdef __cplusplus
 }

--- a/src/params.h
+++ b/src/params.h
@@ -52,6 +52,18 @@ typedef struct Params {
 /// Static information, such as addresses or names, is stored separately.
 extern Params params;
 
+/// Set the param referenced by `idx` to `value`, and set its flags to indicate
+/// that it has been modified and needs to be written to the EEPROM.
+void param_and_flags_set(Params *params, ParamIdx idx, uint8_t value);
+/// Read the bits specified in `mask`
+uint8_t param_flags_get(const Params *params, ParamIdx idx, uint8_t mask);
+/// Set the bits specified in `mask` to 1, leaving the others untouched
+void param_flags_set(Params *params, ParamIdx idx, uint8_t mask);
+/// Clear the bits specified in `mask` to 0, leaving the others untouched
+void param_flags_clear(Params *params, ParamIdx idx, uint8_t mask);
+/// Clear `PARAM_FLAG_MODIFIED` for all parameters
+void param_flags_clear_all_modified(Params *params, Mode mode);
+
 Address param_address(Mode mode, ParamIdx idx);
 
 #if LOGGING_ENABLED

--- a/src/params.h
+++ b/src/params.h
@@ -26,6 +26,13 @@ static const uint8_t mode_num_params[NUM_MODES] = {
     EUCLID_NUM_PARAMS, // EUCLID
 };
 
+/*
+Original EEPROM Schema:
+Channel 1: length = 1 density = 2 offset = 7
+Channel 2: length = 3 density = 4 offset = 8
+Channel 3: length = 5 density = 6 offset = 9
+*/
+
 /// EEPROM addresses for Euclidean mode params. The order is this way for
 /// backwards-compatibility with the original Sebsongs Euclidean firmware.
 static const Address euclid_param_addresses[EUCLID_NUM_PARAMS] = {1, 2, 7, 3, 4, 8, 5, 6, 9};

--- a/src/params.h
+++ b/src/params.h
@@ -31,25 +31,26 @@ static const uint8_t mode_num_params[NUM_MODES] = {
 #define PARAM_FLAG_MODIFIED 0x1
 #define PARAM_FLAG_NEEDS_WRITE 0x2
 
-/// Maximum size of `ParamsRuntime`'s tables. Must be large enough to store the
+/// Maximum size of `Params`'s tables. Must be large enough to store the
 /// `ParamId` type for any mode.
-#define PARAMS_RUNTIME_MAX 9
+#define PARAMS_MAX 9
 
 /// Parameter properties which need to be modified at runtime. Each table has
 /// the same length (`.len`), and they are indexed by a mode's associated
 /// `ParamId` type.
-typedef struct ParamsRuntime {
+typedef struct Params {
 	/// Number of elements in tables
 	uint8_t len;
 	/// List of parameter values of length `.len`. The values are always assumed to be in bounds.
-	uint8_t values[PARAMS_RUNTIME_MAX];
+	uint8_t values[PARAMS_MAX];
 	/// List of parameter properties, stored as bitflags, of length `.len`. Bitflags are indexed
 	/// via `PARAM_FLAG_*` defines.
-	uint8_t flags[PARAMS_RUNTIME_MAX];
-} ParamsRuntime;
+	uint8_t flags[PARAMS_MAX];
+} Params;
 
-/// Stores the runtime information for the active mode's parameters.
-extern ParamsRuntime params;
+/// Stores the runtime-modifiable information for the active mode's parameters.
+/// Static information, such as addresses or names, is stored separately.
+extern Params params;
 
 /*
 Original EEPROM Schema:

--- a/src/params.h
+++ b/src/params.h
@@ -4,6 +4,7 @@
 extern "C" {
 #endif
 
+#include "common/types.h"
 #include "config.h"
 
 #define EUCLID_PARAMS_NUM 9
@@ -11,10 +12,14 @@ extern "C" {
 
 #define PARAMS_TOTAL 9
 
+typedef enum Mode {
+	MODE_EUCLID,
+} Mode;
+
 // clang-format off
 #if LOGGING_ENABLED
 /// Table of parameter names for logging
-static const char params_names[PARAMS_TOTAL][3] = {
+static const char param_names[PARAMS_TOTAL][3] = {
 	// Euclid Mode
 	"L1", // Length, Channel 1
 	"D1", // Density, Channel 1
@@ -26,6 +31,11 @@ static const char params_names[PARAMS_TOTAL][3] = {
 	"D3",
 	"O3",
 };
+
+void param_name(char *result, Mode mode, ParamIdx idx) {
+	strcpy(result, param_names[idx]);	
+}
+
 #endif
 // clang-format on
 


### PR DESCRIPTION
To facilitate the creation of multiple operation modes, this pull request creates a new abstraction, a _parameter_, for storing the persistent data of an operation mode. Parameters are variables (stored as individual bytes) which are programmatically tracked, validated, read from and written to EEPROM, and given names for logging.

As an example, the existing Euclidean mode has three parameters (length, density, and offset) for each of its three channels. These are stored separately from its ephemeral state (sequencer positions and sequencer running state).

Advantages:
- Quicker to implement multiple operation modes, since each mode can reuse parameter-related code
- Quicker to add or modify parameters, since each parameter is no longer handled individually
- Makes implementing multiple modes more binary-size efficient, because parameter code is shared between all modes
- Memory savings from being able to save and load sets of parameters into the parameter tables without having to keep global structs of all modes in memory at once.

Disadvantages:
- Increased code complexity from storing parameters values in tables vs the previous method of global structs
- A slight performance loss due to frequent calculations indexing into tables (cycle time tested at 0.912ms before and 0.936ms after)